### PR TITLE
[gateway/api] ingress poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ crash.*.log
 
 # Ignore org files that I use to generate .md files.
 **/*.org
+
+*.pem
+*.key

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Infra for Mythica.ai
 
-In this repo expect to find definitions for infrastructure. Currently we
-have subdirectories for:
+In this repo expect to find definitions, helpers and code for back end
+infrastructure. Currently this repository is not intended to be shared externally.
 
-- terraform
-- k8s
+DO NOT STORE SECRETS HERE
+
+Do not under any cicumstances store secret data in this repository.
+
+Talk to @jacob or @pedro for secret management patterns.
+
+Currently secrets will be stored in 1password and can be made available
+via their [command line tools](https://developer.1password.com/docs/cli/get-started/#install).
 
 ## Setup
 

--- a/api/.vars
+++ b/api/.vars
@@ -1,0 +1,6 @@
+COMMIT_HASH=$(git rev-parse --short=8 HEAD)
+IMAGE_REPO=us-central1-docker.pkg.dev/controlnet-407314/gke-us-central1-images
+IMAGE_NAME=mythica-web-front
+LOCAL_IMAGE=$IMAGE_NAME:$COMMIT_HASH
+REMOTE_IMAGE=$IMAGE_REPO/$IMAGE_NAME:$COMMIT_HASH
+

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:latest
+
+ENV API_ENDPOINT localhost:5555
+ENV DEX_ENDPOINT localhost:5556
+
+COPY conf/variables.template /etc/nginx/templates/10-variables.conf.template
+COPY conf/upstream.template /etc/nginx/templates/11-upstream.conf.template
+COPY conf/nginx.conf /etc/nginx/
+COPY content /www/html

--- a/api/build.sh
+++ b/api/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#
+source .vars
+docker build --platform linux/amd64 --tag $IMAGE_NAME .

--- a/api/conf/nginx.conf
+++ b/api/conf/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+http {
+    include /etc/nginx/conf.d/*.conf;
+    
+    server {
+        listen 80;
+        proxy_set_header X-Real-IP $external_ip;
+        location / {
+            root /www/html;
+        }
+        location /v1 {
+            proxy_pass http://api/;
+        }
+        location /dex {
+            proxy_pass http://dex/;
+        }
+    }
+}

--- a/api/conf/upstream.template
+++ b/api/conf/upstream.template
@@ -1,0 +1,6 @@
+upstream api {
+    server $API_ENDPOINT;
+}
+upstream dex {
+    server $DEX_ENDPOINT;
+}

--- a/api/conf/variables.template
+++ b/api/conf/variables.template
@@ -1,0 +1,3 @@
+map $host $external_ip {
+     default $EXTERNAL_IP;
+}

--- a/api/content/index.html
+++ b/api/content/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docker Nginx</title>
+</head>
+<body>
+  <h2>Hello from Nginx container</h2>
+</body>
+</html>

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+source .vars
+
+docker tag $IMAGE_NAME:latest $LOCAL_IMAGE
+docker tag $LOCAL_IMAGE $REMOTE_IMAGE 
+docker push $REMOTE_IMAGE
+
+echo "pushed version: $COMMIT_HASH, image: $REMOTE_IMAGE"

--- a/api/deployment.yaml
+++ b/api/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: api
+spec:
+  replicas: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: api-v1
+  template:
+    metadata:
+      labels:
+        app: api-v1
+    spec:
+      containers:
+        - image: us-central1-docker.pkg.dev/controlnet-407314/gke-us-central1-images/mythica-web-front:e70ff1be
+          name: api-v1
+          ports:
+            - containerPort: 80
+              name: http
+      restartPolicy: Always

--- a/api/http-route.yaml
+++ b/api/http-route.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: api
+  namespace: api
+  labels:
+    exposed: "true"
+spec:
+  parentRefs:
+  - kind: Gateway
+    namespace: ingress
+    name: external-gateway
+  hostnames:
+  - "api.mythica.ai"
+  rules:
+  - matches:
+    - path:
+        value: /v1
+    backendRefs:
+    - name: api-v1
+      port: 80

--- a/api/namespace.yaml
+++ b/api/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    exposed: "true"
+  name: api

--- a/api/run.sh
+++ b/api/run.sh
@@ -1,0 +1,1 @@
+docker run --rm -it --name=mythica-web-front mythica-web-front

--- a/api/service.yaml
+++ b/api/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-v1
+  namespace: api
+  labels:
+    app: api
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+  selector:
+    app: api-v1

--- a/ingress/create-gw-ip-address.sh
+++ b/ingress/create-gw-ip-address.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+gcloud compute addresses create mythica-gke-gateway-address \
+    --purpose=SHARED_LOADBALANCER_VIP \
+    --region=us-central1 \
+    --subnet=default \
+    --addresses=10.128.1.1 \
+    --project=controlnet-407314

--- a/ingress/create-proxy-subnet.sh
+++ b/ingress/create-proxy-subnet.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+gcloud compute networks subnets create regional-lb-proxy-subnet \
+	--purpose=REGIONAL_MANAGED_PROXY \
+	--role=ACTIVE \
+	--region=us-central1 \
+	--network=default \
+	--range=10.120.0.0/23 && \
+gcloud compute networks subnets describe regional-lb-proxy-subnet \
+	--regions=us-central1

--- a/ingress/deployment-ingress-controller.yaml
+++ b/ingress/deployment-ingress-controller.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-controller
+  namespace: ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: mythica-gke-public-ip
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-controller
+  template:
+    metadata:
+      labels:
+        app: ingress-controller
+    spec:
+      containers:
+      - name: ingress-controller
+        image: k8s.gcr.io/ingress-nginx/controller:v1.0.0
+        args:
+        - /nginx-ingress-controller
+        - --publish-service=ingress/ingress-controller
+        - --election-id=ingress-controller-leader
+        - --ingress-class=nginx
+        - --configmap=ingress/ingress-controller-config

--- a/ingress/gateway.yaml
+++ b/ingress/gateway.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: external-gateway
+  namespace: ingress
+spec:
+  gatewayClassName: gke-l7-gxlb
+  addresses:
+    - type: NamedAddress
+      value: mythica-gke-global-gateway-address
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes: &allowedRoutes
+        kinds:
+          - group: gateway.networking.k8s.io
+            kind: HTTPRoute
+        namespaces:
+          from: Selector
+          selector:
+           matchLabels:
+              exposed: "true"
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+         - name: mythica-ai-cert
+      allowedRoutes: *allowedRoutes

--- a/ingress/namespace.yaml
+++ b/ingress/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress
+  labels:
+    shared-gateway-access: "true"


### PR DESCRIPTION
This change integrates the latest Google Xglb tech with HTTP routes to enable cross-namespace routing from a global load balancer in GKE.

The namespaces provide an exposed=true label to allow the gateway controller to match the route. The routes are specified within the namespace.

This POC lands traffic to dex and our API at /v1, the service is hard versioned v1 for now. 