### PR TITLE
[api/app] default the sql connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ testing/mnt/*/**
 
 # site pointers
 sites/*.txt
+
+__pycache__

--- a/api/app/models/db/connection.py
+++ b/api/app/models/db/connection.py
@@ -5,7 +5,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm import sessionmaker
 
-engine_url = os.environ.get('SQL_URL').strip()
+engine_url = os.environ.get('SQL_URL', 'postgresql://test:test@localhost:5432/upload_pipeline').strip()
 engine = create_engine(engine_url)
 
 


### PR DESCRIPTION
when not running in a container use localhost to connect to the local storage testing infrastructure