### PR TITLE
[nginx] redirect to react router

### DIFF
--- a/api/nginx/conf/nginx.conf
+++ b/api/nginx/conf/nginx.conf
@@ -16,11 +16,10 @@ http {
         proxy_set_header X-Real-IP $external_ip;
         proxy_set_header Host $host;
 
-        #access_log  /var/log/nginx/host.access.log  main;
-
         location / {
             root   /sites/jungle3/dist;
-            index  index.html index.htm;
+            index  index.html;
+            try_files $uri /index.html;
         }
         location  /api/v1  {
             proxy_pass http://localhost:5555/;
@@ -49,8 +48,5 @@ http {
             proxy_busy_buffers_size    64k;
             proxy_temp_file_write_size 64k;
         }
-        #location /dex {
-        #    proxy_pass http://dex/;
-        #}
     }
 }


### PR DESCRIPTION
redirects the SPA react-router links to the index.html 