### PR TITLE
[jungle3] add updated jungle files

### DIFF
--- a/sites/jungle3/.env
+++ b/sites/jungle3/.env
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:5555/v1
+VITE_API_BASE_URL=http://localhost:50555/v1
+VITE_IMAGES_BASE_URL=http://localhost:8080/images

--- a/sites/jungle3/.env.debug
+++ b/sites/jungle3/.env.debug
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:5555/v1
+VITE_IMAGES_BASE_URL=http://localhost:9000/images


### PR DESCRIPTION
When running in a debugger default port is 5555 for the app and 9000 for minio (on docker proxy port)
When running from inside docker proxy port is 50555 for app and minio is proxied through nginx 8080
When running from production, the API handles path redirection