### PR TITLE
[api/app] increase client upload limit on nginx

### DIFF
--- a/api/nginx/conf/nginx-gke.conf
+++ b/api/nginx/conf/nginx-gke.conf
@@ -39,6 +39,8 @@ http {
             proxy_buffers              4 32k;
             proxy_busy_buffers_size    64k;
             proxy_temp_file_write_size 64k;
+
+            client_max_body_size       100M;
         }
 
         location  /docs  {


### PR DESCRIPTION
This increases the object size allowed at the front of the app. There are multiple issues downstream of this. Ultimately the uploads should be made through a pre-signed URL directly to the storage system but this is a larger change.