### PR TITLE
[gcs] ensure the zonal network endpoint group is defined

### DIFF
--- a/api/k8s/httphealthcheck-web-front.yaml
+++ b/api/k8s/httphealthcheck-web-front.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: web-front
+  namespace: api
+spec:
+  default:
+    checkIntervalSec: 5
+    timeoutSec: 3
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    logConfig:
+      enabled: true
+    config:
+      type: HTTP
+      httpHealthCheck:
+        portSpecification: USE_NAMED_PORT
+        portName: http
+        host: api.mythica.ai
+        requestPath: /healthz
+  targetRef:
+    group: ""
+    kind: Service
+    name: web-front

--- a/api/k8s/service-web-front.yaml
+++ b/api/k8s/service-web-front.yaml
@@ -10,6 +10,7 @@ metadata:
     release: production
   annotations:
     networking.gke.io/load-balancer-type: "Internal"
+    cloud.google.com/neg: '{"exposed_ports": {"80":{}}}'
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
There was an issue where the network endpoint group was lost from a previous service configuration, causing an unhealthy upstream.
It seem that an annotation is required on the service
A specific health check was also implemented to reduce hits against the main resource on the service