### PR TITLE
[api/houdini] Fix export_mesh outputting time dependent data

### DIFF
--- a/api/houdini/automation/export_mesh.py
+++ b/api/houdini/automation/export_mesh.py
@@ -115,6 +115,7 @@ def export_mesh(hdapath, output_path, output_file_name, format, parms_file):
         output_file_path = os.path.join(output_path, f"{output_file_name}.usd")
         usd_node = geo.createNode("usdexport","usd_node")
         usd_node.parm("lopoutput").set(output_file_path)
+        usd_node.parm("authortimesamples").set("never")
         usd_node.setInput(0, asset, 0)
         usd_node.parm("execute").pressButton()
 


### PR DESCRIPTION
A USD file can contain time varying data. Usually when you just use SOP nodes to generate geometry and then use a USDExport node to output that mesh, it will just output that geometry data without any time information.

However if you load input data with a USDImport node, it will by default load that as time varying data. This will cause the USDExport node to output a USD file that contains a time series of data with a single "Time 1" frame.

This causes problems with the Unreal USD importer. The default settings of Houdini and Unreal have a different starting frame number (Houdini uses "Time 1" and Unreal uses "Time 0" for the first frame).

If there is no time information in the USD file it will just work. However because Houdini/Unreal use different starting frame numbers, it will cause this to fail to import since it will look for the wrong frame number.

We currently aren't using this time varying data feature, so working around by forcing the USDExporter to not output this time information. In the future if we do need this, we can likely fix it by changing the USD import settings on the Unreal side.