### PR TITLE
[api/app] Fix error failing to find crypto extra

### DIFF
--- a/api/app/poetry.lock
+++ b/api/app/poetry.lock
@@ -1520,6 +1520,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = false
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
     {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
 ]
 
@@ -1530,6 +1531,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = false
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd"},
     {file = "pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c"},
 ]
 
@@ -1778,6 +1780,9 @@ files = [
     {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
     {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
 ]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
@@ -2244,13 +2249,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
+    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
 ]
 
 [package.extras]
@@ -2522,10 +2527,9 @@ files = [
 [extras]
 authlib = []
 pgsql = ["psycopg2-binary"]
-pyjwt = []
 sqlalchemy = ["asyncio"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "<4.0,>=3.10"
-content-hash = "9e9526a176dd9ea60e2f063a86e905aa117e4aa3aeb17816f009493069d1b490"
+content-hash = "a34d523d2a0967e686a68576795e51845f9029ab0adbf9a83c664b3c5a6e5956"

--- a/api/app/pyproject.toml
+++ b/api/app/pyproject.toml
@@ -29,7 +29,7 @@ asyncio = "3.4.3"
 python-json-logger = "2.0.7"
 base58 = "2.1.1"
 authlib = "1.3.1"
-pyjwt = "2.8.0"
+pyjwt = { version = "2.8.0", extras = ["crypto"] }
 fastapi-auth0 = "0.5.0"
 starlette = "0.37.2"
 tzdata = "2024.1"
@@ -37,7 +37,6 @@ tzdata = "2024.1"
 [tool.poetry.extras]
 pgsql = ["psycopg2-binary"]
 sqlalchemy = ["asyncio"]
-pyjwt = ["crypto"]
 authlib = []
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
When using "inv docker-build" I was hitting this error:

 > [7/7] RUN poetry check &&     poetry env use python3 &&     poetry install --compile --all-extras --without=dev --no-root:
0.638 Error: Cannot find dependency "crypto" for extra "pyjwt" in main dependencies.

It looks like this may have just been using the wrong syntax? This change fixes the docker build and the auth_token tests pass.