### PR TITLE
[api/houdini] Support for export_mesh binding to existing Unreal material

### DIFF
--- a/api/houdini-worker/houdini_worker.py
+++ b/api/houdini-worker/houdini_worker.py
@@ -101,7 +101,8 @@ def process_generate_mesh_job_impl(runner, o, endpoint: str, event_seq: int, tok
 
         # Prepare the parameters file
         parms_data = {
-            'parms': o.params,
+            'mesh_parms': o.params.mesh_params,
+            'material_parms': o.params.material_params,
             'inputs': input_files_local
         }
 

--- a/api/houdini/automation/export_mesh.py
+++ b/api/houdini/automation/export_mesh.py
@@ -67,7 +67,7 @@ def export_mesh(hdapath, output_path, output_file_name, format, parms_file):
     asset = geo.createNode(assetdef.nodeTypeName())
 
     # Set parms
-    for k, v in parms_data['parms'].items():
+    for k, v in parms_data['mesh_parms'].items():
         # TODO: Support ramp parameters
         if not isinstance(v, dict):
             val = [v] if not (isinstance(v, tuple) or isinstance(v, list)) else v
@@ -138,7 +138,6 @@ def export_mesh(hdapath, output_path, output_file_name, format, parms_file):
             render_node.setInput(0, attrib_node, 0)
             render_node.parm("execute").pressButton()
 
-            os.remove(output_file_path)
             output_file_path = binded_file
 
         # Convert to USDZ format


### PR DESCRIPTION
The USD syntax for this is unfortunately Unreal specific. So I have added a "type" field to "material_params" section to hint the server which format it expects to import it as. We may need to add more types in the future for other client types.