### PR TITLE
[api/houdini-worker] Gracefully handle houdini process crashing

### DIFF
--- a/api/houdini-worker/houdini_worker.py
+++ b/api/houdini-worker/houdini_worker.py
@@ -323,7 +323,11 @@ class HoudiniJobRunner:
             self.process = None
 
     def _execute_job_impl(self, job) -> bool:
-        os.write(self.parent_to_child_write, job.encode() + b'\n')
+        try:
+            os.write(self.parent_to_child_write, job.encode() + b'\n')
+        except Exception as e:
+            log.error("Failed to send job data to child process")
+            return False
 
         ready, _, _ = select.select([self.child_to_parent_read], [], [], self.job_timeout)
         if not ready:


### PR DESCRIPTION
When I leave the docker image running overnight, the hython process always seems to have crashed which causes the houdini-worker to also crash and stop working. Not sure the exact root cause of why the hython process crashes when idle for a long time, but this will make it restart the hython process to gracefully handle cases like this.