### PR TITLE
[api/houdini] Fix /job/definitions error 500 due to invalid utf-8 string data

### DIFF
--- a/api/houdini/darol-plugin/scripts/python/mythica/network.py
+++ b/api/houdini/darol-plugin/scripts/python/mythica/network.py
@@ -909,12 +909,13 @@ def _get_litegraph_tab_menu(nt):
 
     return f"{nt.category().name().upper()}/{ret}"
         
-
+def sanitize_utf8(s):
+    return s.encode('utf-8', errors='replace').decode('utf-8', errors='replace')
 
 def _get_parm_defaults(parmtemp):
     _parm = {
         "type":parmtemp.type().name(),
-        "label":parmtemp.label(),
+        "label":sanitize_utf8(parmtemp.label()),
     }
     if hasattr(parmtemp, "minValue"):
         _parm["min"] = parmtemp.minValue()


### PR DESCRIPTION
When returning string data through the API, the pydantic response type is serialized to utf-8 json using strict validation. This will cause the request to fail if the response data contains any invalid utf-8 strings.

The /jobs/definitions query was hitting this issue. The JobDefinitionModel::params_schema::label field specifically contains a display name string that is extracted from the HDA file. Specially the "FE-ELib for Houdini" package contains an HDA "FeE Chinese Eaves.hda" that contains a parameter with the label "\u6a90\u6b65\u957f\udca5\u957f".

This string appears to be a utf-16 string. The "\udca5" code point is used by utf-16 encoding but isn't valid for utf-8.

Fixed this issue by sanitizing the string immediately after extracting it from the HDA.