### PR TITLE
[ingress] fix images.* unhealthy upstream 503

### DIFF
--- a/api/k8s/deployment-gcs-proxy.yaml
+++ b/api/k8s/deployment-gcs-proxy.yaml
@@ -35,5 +35,5 @@ spec:
               cpu: "500m"
           ports:
             - containerPort: 80
-              name: http-proxy
+              name: http
       restartPolicy: Always

--- a/api/k8s/httphealthcheck-gcs-proxy.yaml
+++ b/api/k8s/httphealthcheck-gcs-proxy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: gcs-proxy
+  namespace: api
+spec:
+  default:
+    checkIntervalSec: 5
+    timeoutSec: 3
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    logConfig:
+      enabled: true
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 80
+        host: images.mythica.ai
+        requestPath: /_health
+  targetRef:
+    group: ""
+    kind: Service
+    name: gcs-proxy

--- a/api/k8s/httproute-web-front.yaml
+++ b/api/k8s/httproute-web-front.yaml
@@ -11,12 +11,12 @@ spec:
       namespace: ingress
       name: external-gateway
   hostnames:
+    - "oss.mythica.ai"
     - "api.mythica.ai"
-    - "images.mythica.ai"
-    - "cache.mythica.ai"
-    - "pcgindex.mythica.ai"
-    - "files.mythica.ai"
     - "dex.mythica.ai"
+    - "oss.mythica.gg"
+    - "api.mythica.gg"
+    - "dex.mythica.gg"
   rules:
     - matches:
         - path:

--- a/api/k8s/service-gcs-proxy.yaml
+++ b/api/k8s/service-gcs-proxy.yaml
@@ -15,6 +15,6 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: http-proxy
+      targetPort: 80
   selector:
     app: gcs-proxy


### PR DESCRIPTION
images.mythica.ai,gg routes through our public google ingress even though the gcs route is attached to the gateway.ingress there was a missing health check

took opportunity to simplify some hosts as well