### PR TITLE
[automation] Workaround large docker build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+testing


### PR DESCRIPTION
We have a number of images that we want to include the ripple lib into. Our current pattern for doing this is to set the "working_directory" of the docker build to be the root directory of the repo. That way is has access to copy files from the /lib directory into the image.

This pattern can cause performance issues with the docker build however. When it prepares to build the image, it will scan/copy all of the files within the working directory into it's "context". There are some directories such as "testing" that may contain multiple GB of data which causes this to take multiple minutes.

The best solution here is likely to reorganize our repo structure to avoid this issue. To mitigate the issue for now, I have added a .dockerignore files to skip the largest unnecessary files from this context scan. With this workaround, it will still take ~15 seconds to load the context.