### PR TITLE
[jungle3] Introduced private routes. Fixed couple of asset-related bugs

### DIFF
--- a/sites/jungle3/src/App.tsx
+++ b/sites/jungle3/src/App.tsx
@@ -7,6 +7,7 @@ import { lazyRetry } from "@services/lazyImport.ts";
 import { CookieConsentBanner } from "@components/CookieConsentBanner";
 import { useOnboarding } from "@hooks/useOnboarding";
 import { ProductTour } from "@components/ProductTour";
+import { PrivateRoute } from "@components/PrivateRoute";
 import "./styles/App.css";
 
 const Dashboard = lazy(() => lazyRetry(() => import("@pages/Dashboard")));
@@ -21,7 +22,6 @@ const AssetEditWrapper = lazy(() =>
   lazyRetry(() => import("@pages/AssetEdit")),
 );
 const OrgsList = lazy(() => lazyRetry(() => import("@pages/OrgsList")));
-const Login = lazy(() => lazyRetry(() => import("@pages/Login")));
 const Logout = lazy(() => lazyRetry(() => import("@pages/Logout")));
 const FileViewWrapper = lazy(() => lazyRetry(() => import("@pages/FileView")));
 const PackageViewWrapper = lazy(() =>
@@ -45,17 +45,31 @@ const App: React.FC = () => {
       <Routes>
         <Route path="*" element={<Layout />} errorElement={<ErrorPage />}>
           <Route index element={<Assets />} />
-          <Route path="dashboard" element={<Dashboard />} />
-          <Route path="profile" element={<ProfileSettings />} />
-          <Route path="packages" element={<Packages />} />
-          <Route path="uploads" element={<Uploads />} />
-          <Route path="api-keys" element={<ApiKeys />} />
+          <Route
+            path="dashboard"
+            element={<PrivateRoute component={Dashboard} />}
+          />
+          <Route
+            path="profile"
+            element={<PrivateRoute component={ProfileSettings} />}
+          />
+          <Route
+            path="packages"
+            element={<PrivateRoute component={Packages} />}
+          />
+          <Route
+            path="uploads"
+            element={<PrivateRoute component={Uploads} />}
+          />
+          <Route
+            path="api-keys"
+            element={<PrivateRoute component={ApiKeys} />}
+          />
           <Route
             path="assets/:asset_id/versions/:version"
             element={<AssetEditWrapper />}
           />
-          <Route path="orgs" element={<OrgsList />} />
-          <Route path="login" element={<Login />} />
+          <Route path="orgs" element={<PrivateRoute component={OrgsList} />} />
           <Route path="logout" element={<Logout />} />
           <Route path="files/:file_id" element={<FileViewWrapper />} />
           <Route

--- a/sites/jungle3/src/components/AssetEdit/AssetEditVersionDropdown.tsx
+++ b/sites/jungle3/src/components/AssetEdit/AssetEditVersionDropdown.tsx
@@ -110,7 +110,7 @@ export const AssetEditVersionDropdown = () => {
   const id = open ? "simple-popper" : undefined;
 
   React.useEffect(() => {
-    if (isVersionZero(sanitizedVersion)) {
+    if (isVersionZero(sanitizedVersion) || isVersionZero(version)) {
       const defaultVersion = "1.0.0";
       const newSanitizedVersion = sanitizeVersion(
         convertUserVersion(defaultVersion),

--- a/sites/jungle3/src/components/PrivateRoute/index.tsx
+++ b/sites/jungle3/src/components/PrivateRoute/index.tsx
@@ -1,0 +1,15 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import * as React from "react";
+import { Navigate, RouteProps } from "react-router-dom";
+
+type Props = RouteProps & {
+  component: React.ElementType;
+};
+
+export const PrivateRoute: React.FC<Props> = ({ component: Component }) => {
+  const { isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) return null;
+
+  return isAuthenticated ? <Component /> : <Navigate to="/" replace />;
+};

--- a/sites/jungle3/src/pages/AssetEdit.tsx
+++ b/sites/jungle3/src/pages/AssetEdit.tsx
@@ -104,6 +104,7 @@ const AssetEdit: React.FC<AssetEditProps> = ({
       commit_ref: r.commit_ref || "",
       created: r.created || "",
       updated: r.updated,
+      published: r.published,
       files: {},
       thumbnails: {},
       links: [],

--- a/sites/jungle3/src/services/api/config.ts
+++ b/sites/jungle3/src/services/api/config.ts
@@ -14,7 +14,7 @@ const apiConfig: ApiConfigType = {
    * Used to redirect for unauthorized calls
    * @see redirectToPage.js
    */
-  loginPath: ApiUrl.LOGIN,
+  loginPath: ApiUrl.BASE,
 
   /**
    * Default API to choose if no option is given

--- a/sites/jungle3/src/services/api/enums.ts
+++ b/sites/jungle3/src/services/api/enums.ts
@@ -15,4 +15,5 @@ export enum ErrorMessage {
 export enum ApiUrl {
   LOGIN = "/login",
   DEFAULT = "default",
+  BASE = "/",
 }


### PR DESCRIPTION
- Added private routes for pages: Dashboard, Profile Settings, Packages, Uploads, Api Keys, Orgs. Meaning unauthenticated users will be redirected to index page if they try to access those pages (e.g. by entering URL in browser manually)
- **Fixed**: _draft/publish status is not reflecting database value when editing a package_ 
- **Fixed**:  _When creating a package, it is still reporting 0.0.0 is invalid version although version field has been populated with 1.0.0_