### PR TITLE
[api/app] Request job def generation on HDA upload

### DIFF
--- a/api/app/db/index.py
+++ b/api/app/db/index.py
@@ -75,6 +75,6 @@ def update(ctx: RequestContext) -> Tuple[str, str]:
             )
 
             nats = NatsAdapter()
-            asyncio.create_task(nats.post("houdini", event))
+            asyncio.create_task(nats.post("houdini", event.model_dump()))
 
     return file_id, event_id


### PR DESCRIPTION
This has only been tested locally with no NATS server. So the logic just produces an error that it failed to find the server.