### PR TITLE
[api/app] Add job integration test

### DIFF
--- a/api/app/tests/job_integration_test.py
+++ b/api/app/tests/job_integration_test.py
@@ -1,8 +1,10 @@
 import requests
-from typing import Optional
+import time
+
 
 ENDPOINT = "https://api.mythica.ai/v1"
 PROFILE_ID = "prf_2fXUBxeTyD7TXBjTHHz41MitSpG"
+JOB_DEF_ID = "jobdef_3L84Ln8H9mnxvyhhJDbLq3mbrefR"
 
 
 def start_session(endpoint: str, profile_id: str) -> str:
@@ -14,9 +16,47 @@ def start_session(endpoint: str, profile_id: str) -> str:
     return result['token']
 
 
+def request_job(endpoint: str, headers: str) -> str:
+    body = {
+        "job_def_id": JOB_DEF_ID,
+        "input_files": [],
+        "params": {}
+    }
+
+    url = f"{endpoint}/jobs/"
+    response = requests.post(url, headers=headers, timeout=10, json=body)
+    response.raise_for_status()
+
+    result = response.json()
+    return result['job_id']
+
+
+def check_job_status(endpoint: str, headers: str, job_id: str) -> bool:
+    url = f"{endpoint}/jobs/results/{job_id}"
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    result = response.json()
+    print(f"Received result: {result}")
+
+    return result['completed']
+
+
 def main():
     token = start_session(ENDPOINT, PROFILE_ID)
-    print(token)
+    headers = {"Authorization": f"Bearer {token}"}
+    print(f"Got token: {token}")
+
+    job_id = request_job(ENDPOINT, headers)
+    print(f"Started job: {job_id}")
+ 
+    while True:
+        completed = check_job_status(ENDPOINT, headers, job_id)
+        if completed:
+            break
+        time.sleep(1)
+
+    print("Job completed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is intentionally not hooked up to the CI tests. For now this is just a test I manually run to test job system changes.

As we get the new job system fully stood up, we can evolve this script into a canary test we can deploy.

I want to commit this WIP version now so I can iterate on it in parallel to job system changes going in.