### PR TITLE
[api/app] Expose profileId to workers

### DIFF
--- a/api/app/routes/jobs/jobs.py
+++ b/api/app/routes/jobs/jobs.py
@@ -115,14 +115,13 @@ def add_job_requested_event(session: Session, job_seq: int, job_def, params: str
     return event_result
 
 
-def add_job_nats_event(job_seq: int, job_type: str, params: ParameterSet):
-    job_id = job_seq_to_id(job_seq)
-
+def add_job_nats_event(job_seq: int, profile_seq: int, job_type: str, params: ParameterSet):
     [subject, path] = job_type.split("::")
 
     event = WorkerRequest(
         work_id=str(uuid4()),
-        job_id=job_id,
+        job_id=job_seq_to_id(job_seq),
+        profile_id=profile_seq_to_id(profile_seq),
         path=path,
         data=params.model_dump()
     )
@@ -157,7 +156,7 @@ async def create_job(
         event_id = event_seq_to_id(event_result.inserted_primary_key[0])
         session.commit()
 
-        add_job_nats_event(job_seq, job_def.job_type, request.params)
+        add_job_nats_event(job_seq, profile.profile_seq, job_def.job_type, request.params)
 
         return JobResponse(
             job_id=job_seq_to_id(job_seq),

--- a/libs/python/ripple/ripple/automation.py
+++ b/libs/python/ripple/ripple/automation.py
@@ -127,7 +127,8 @@ class WorkerModel(BaseModel):
 class WorkerRequest(BaseModel):
     """Contract for requests for work"""
     work_id: str
-    job_id: Optional[str] = None  # job_id is optional
+    job_id: Optional[str] = None
+    profile_id: Optional[str] = None
     path: str
     data: Dict
 
@@ -210,7 +211,7 @@ class Worker:
             try:
                 payload = WorkerRequest(**json_payload)
 
-                log_str = f"work_id:{payload.work_id}, work:{payload.path}, job_id: {payload.job_id}, data: {payload.data}"
+                log_str = f"work_id:{payload.work_id}, work:{payload.path}, job_id: {payload.job_id}, profile_id: {payload.profile_id}, data: {payload.data}"
 
                 #TODO: These should be defined elsewhere.
 


### PR DESCRIPTION
This is required for interacting with with API endpoints that require authentication. For example, the generate_mesh work unit needs this to do file uploads.