### PR TITLE
[houdini] Fix error generating job defs

### DIFF
--- a/automation/houdini/automation/generate_job_defs.py
+++ b/automation/houdini/automation/generate_job_defs.py
@@ -40,7 +40,7 @@ def set_config_params(param_spec: ParameterSpec, hda_file_id: str, index: int):
         label='HDA Definition Index', 
         constant=True, 
         default=index
-    ),
+    )
     param_spec.params['format'] = StringParameterSpec(
         label='Format', 
         constant=True, 


### PR DESCRIPTION
This typo was causing the value of the 'hda_definition_index' key to be wrapped in a tuple.