### PR TITLE
[api/app] Update job tests to new the ParameterSet schema

### DIFF
--- a/api/app/tests/test_jobs.py
+++ b/api/app/tests/test_jobs.py
@@ -66,9 +66,7 @@ def test_create_update(client, api_base, create_profile):
                     json={
                         'job_def_id': "INVALID",
                         'params': {
-                            'params': {
-                                'size': 5.0
-                            }
+                            'size': 5.0
                         }
                     },
                     headers=headers)
@@ -78,9 +76,7 @@ def test_create_update(client, api_base, create_profile):
     r = client.post(f'{api_base}/jobs',
                     json={
                         'job_def_id': job_def_id,
-                        'params': {
-                            'params': {}
-                        }
+                        'params': {}
                     },
                     headers=headers)
     assert_status_code(r, HTTPStatus.BAD_REQUEST)
@@ -90,9 +86,7 @@ def test_create_update(client, api_base, create_profile):
                     json={
                         'job_def_id': job_def_id,
                         'params': {
-                            'params': {
-                                'size': 5.0
-                            }
+                            'size': 5.0
                         }
                     },
                     headers=headers)


### PR DESCRIPTION
These job tests are still failing due to a second issue that will be addressed in another PR. 

This PR just updates the tests to be compatible with the new schema to unblock investigating the second issue.