### PR TITLE
[automation] Fix error when not specifying geometry input

### DIFF
--- a/automation/houdini/automation/generate_mesh.py
+++ b/automation/houdini/automation/generate_mesh.py
@@ -32,7 +32,7 @@ def create_inputs(asset, geo, params: dict):
             continue
 
         input_index = int(match.group(1))
-        input_file = v['file_path']
+        input_file = v.get('file_path', '')
 
         input_node = None
         if os.path.exists(input_file):


### PR DESCRIPTION
An error would occur if the Unreal tries to request a job that expects input geometry but didn't specify any. This would cause the client to get into a bad state.

With the new ParameterSet typing there is a parsing ambiguity with FileParameter types.

The payload {"file_id": "file_xxxx"} is ambiguous whether it should be parsed as a FileParameter type or a dict. This will get parsed as a dict when previous it would have been parsed as a FileParameter.

To work around this, we need to duck-type any dict parameter values objects to check if they may actually be a FileParameter. Specifically it means code reading ParameterSet needs to manually handle the case where the optional "file_path" field may not be in the object.