### PR TITLE
[automation,nats] Enable jetstream and clustered nats deployment

### DIFF
--- a/k8s/nats/config.yaml
+++ b/k8s/nats/config.yaml
@@ -1,0 +1,15 @@
+config:
+  cluster:
+    enabled: true
+    replicas: 3
+  jetstream:
+    enabled: true
+    fileStore:
+      pvc:
+        size: 10Gi
+
+podTemplate:
+  topologySpreadConstraints:
+    kubernetes.io/hostname:
+      maxSkew: 1
+      whenUnsatisfiable: DoNotSchedule

--- a/k8s/nats/install.sh
+++ b/k8s/nats/install.sh
@@ -25,6 +25,6 @@ create_namespace ${NAMESPACE}
 kubectl config set-context --current --namespace=${NAMESPACE}
 
 helm repo add nats https://nats-io.github.io/k8s/helm/charts/
-helm install nats nats/nats
+helm install nats nats/nats -f config.yaml
 
 kubectl apply -f nats-lb.yaml


### PR DESCRIPTION
With jetstream, we enable asynchronous clients to send jobs to nats and pull job results from the queue rather than sit subscribed to it. 
We also enable 'exactly once' delivery (nats without jetstream supports 'at least once' delivery to queue subscribers)