### PR TITLE
[sites,jungle3] runtime (startup) environment variables

### DIFF
--- a/api/helm/api/templates/deployment-web-front.yaml
+++ b/api/helm/api/templates/deployment-web-front.yaml
@@ -29,6 +29,19 @@ spec:
           command: [ "/bin/sh", "-c" ]
           args:
             - cp -R /dist/jungle3 /dist-publish/jungle3
+          env:
+            - name: VITE_API_BASE_URL
+              value: {{ .Values.apiBaseUrl }}
+            - name: VITE_IMAGES_BASE_URL
+              value: {{ .Values.imagesBaseUrl}}
+            - name: VITE_AUTH0_DOMAIN
+              value: {{ .Values.auth0.domain}}
+            - name: VITE_AUTH0_CLIENT_ID
+              value: {{ .Values.auth0.clientId }}
+            - name: VITE_AUTH0_AUDIENCE
+              value: {{ .Values.auth0.audience }}
+            - name: VITE_AUTH0_REDIRECT_URL
+              value: {{ .Values.auth0.redirectUrl }}
           volumeMounts:
             - name: dist-publish
               mountPath: "/dist-publish"

--- a/api/helm/api/values-staging.yaml
+++ b/api/helm/api/values-staging.yaml
@@ -17,6 +17,15 @@ domains:
   - dex-staging.mythica.ai
 serviceAccount:
   secretName: front-end-api-staging-sa
+
+apiBase: https://api-staging.mythica.ai/v1
+imagesBaseUrl: https://api-staging.mythica.ai/images
+
+auth0Domain: dev-dtvqj0iuc5rnb6x2.us.auth0.com
+auth0ClientId: nW2QQHrHc687F6WbZdzgZdd4BFzHMQXl
+auth0Audience: https://api-staging.mythica.ai/v1
+auth0RedirectUrl: https://api-staging.mythica.ai
+
 api:
   app:
     tag: "latest"

--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -19,6 +19,15 @@ domains:
   - dex.mythica.ai
   - dex.mythica.gg
 
+apiBaseUrl: "https://api.mythica.ai/v1"
+imagesBaseUrl: "https://api.mythica.ai/images"
+
+auth0:
+  domain: dev-dtvqj0iuc5rnb6x2.us.auth0.com
+  clientId: caa07HclGxulrcv43hgGziNJx7cQ8GED
+  audience: https://api.mythica.ai/v1
+  redirectUrl: https://api.mythica.ai
+
 serviceAccount:
   secretName: front-end-api-sa
 api:

--- a/sites/jungle3/Dockerfile
+++ b/sites/jungle3/Dockerfile
@@ -32,5 +32,13 @@ RUN pnpm run build -m "${NODE_ENV}"
 # structure, to support mounting multiple site builds give each dist
 # folder the name of the mounted site
 FROM alpine:latest
+# Install envsubst for runtime environment substitution
+RUN apk add gettext
+
+WORKDIR /
+COPY docker-entrypoint.sh .
+
 WORKDIR /dist/jungle3
 COPY --from=build /build/dist .
+RUN mv index.html index.html.template
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/sites/jungle3/README.md
+++ b/sites/jungle3/README.md
@@ -28,3 +28,30 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Usage of environment variables
+
+External variables are exposed using a combination of Vite's [env and mode](https://vite.dev/guide/env-and-mode), the vite-plugin-runtime-env and environment variables from the containing environment.
+
+There are three modes we expect the site to run in:
+
+- local debug
+- local containerized (via docker-compose, inv web-start)
+- k8s containerized (via api/web-front and it's deployment)
+
+In local debug the .env.debug file should be referenced
+
+  `vite dev -m debug`
+
+In containerized mode the environment variables are defined in the docker-compose file.
+
+In K8s mode the environment variables are defined in the deployment.yaml
+
+
+Here's the process:
+
+1. Build container is built using vite and the content is placed in /dist/<site-name>
+2. Init container is created using a --from=build which copies only the dist files 
+3. At runtime the init container does an `envsubst` on the vite variables to allow the current environment to generate a working index.html for the site.
+
+

--- a/sites/jungle3/docker-entrypoint.sh
+++ b/sites/jungle3/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# do the runtime variable substitutions
+cat index.html.template
+envsubst < index.html.template > index.html
+echo "envsubst finished on $PWD/index.html"
+cat index.html

--- a/sites/jungle3/package.json
+++ b/sites/jungle3/package.json
@@ -89,6 +89,7 @@
     "ts-jest": "^29.2.1",
     "typescript": "^5.5.2",
     "vite": "^5.3.1",
+    "vite-plugin-runtime-env": "^0.1.1",
     "vite-tsconfig-paths": "^5.0.1"
   },
   "packageManager": "pnpm@9.1.2+sha512.127dc83b9ea10c32be65d22a8efb4a65fb952e8fefbdfded39bdc3c97efc32d31b48b00420df2c1187ace28c921c902f0cb5a134a4d032b8b5295cbfa2c681e2"

--- a/sites/jungle3/pnpm-lock.yaml
+++ b/sites/jungle3/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       vite:
         specifier: ^5.3.1
         version: 5.4.3(@types/node@20.16.4)
+      vite-plugin-runtime-env:
+        specifier: ^0.1.1
+        version: 0.1.1(vite@5.4.3(@types/node@20.16.4))
       vite-tsconfig-paths:
         specifier: ^5.0.1
         version: 5.0.1(typescript@5.5.4)(vite@5.4.3(@types/node@20.16.4))
@@ -4579,6 +4582,11 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-plugin-runtime-env@0.1.1:
+    resolution: {integrity: sha512-xm7aw/BV2o6avLi1UCR9mIG+KZVv2UQhoqb4gUIxhiP7hkiLCYnG3aTFLYrHb8CmAzXkTvBRb63yOnAgJWYbgA==}
+    peerDependencies:
+      vite: '*'
 
   vite-tsconfig-paths@5.0.1:
     resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
@@ -9807,6 +9815,11 @@ snapshots:
       convert-source-map: 2.0.0
 
   vary@1.1.2: {}
+
+  vite-plugin-runtime-env@0.1.1(vite@5.4.3(@types/node@20.16.4)):
+    dependencies:
+      magic-string: 0.30.11
+      vite: 5.4.3(@types/node@20.16.4)
 
   vite-tsconfig-paths@5.0.1(typescript@5.5.4)(vite@5.4.3(@types/node@20.16.4)):
     dependencies:

--- a/sites/jungle3/vite.config.ts
+++ b/sites/jungle3/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vite";
+import runtimeEnv from 'vite-plugin-runtime-env';
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react(), tsconfigPaths(), runtimeEnv()],
 });

--- a/testing/web/docker-compose.yaml
+++ b/testing/web/docker-compose.yaml
@@ -8,6 +8,13 @@ services:
     image: mythica-jungle3-build:latest
     volumes:
       - dist:/dist
+    environment:
+      VITE_API_BASE_URL: http://localhost:50555/v1
+      VITE_IMAGES_BASE_URL: http://localhost:8080/images
+      VITE_AUTH0_DOMAIN: dev-dtvqj0iuc5rnb6x2.us.auth0.com
+      VITE_AUTH0_CLIENT_ID: 4CZhQWoNm1WH8l8042LeF38qHrUTR2ax
+      VITE_AUTH0_AUDIENCE: http://localhost:50555/v1
+      VITE_AUTH0_REDIRECT_URL: http://localhost:8080
   editor:
     container_name: editor
     image: mythica-editor-build:latest


### PR DESCRIPTION
This allows jungle3 to use environment variables to control runtime behavior. Multiple build images are no longer required to support local, staging and production environments.