### PR TITLE
[fix] keep file purpose API profile scoped

### DIFF
--- a/api/app/routes/files/files.py
+++ b/api/app/routes/files/files.py
@@ -9,10 +9,9 @@ from cryptid.cryptid import file_id_to_seq, profile_id_to_seq
 from db.connection import get_session
 from db.schema.media import FileContent
 from db.schema.profiles import Profile
+from ripple.models.contexts import FilePurpose
 from routes.authorization import current_profile, current_profile_id
 from routes.file_uploads import FileUploadResponse, enrich_file, enrich_files
-
-from ripple.models.contexts import FilePurpose
 
 router = APIRouter(prefix="/files", tags=["files"])
 
@@ -47,6 +46,7 @@ async def get_file_by_content(
             .where(FileContent.deleted == None))).first()
         return enrich_file(session, file, profile)
 
+
 @router.get("/by_purpose/{file_purpose}")
 async def get_file_by_purpose(
         file_purpose: FilePurpose,
@@ -55,9 +55,11 @@ async def get_file_by_purpose(
     with get_session() as session:
         files = session.exec((
             select(FileContent)
+            .where(FileContent.owner_seq == profile.profile_seq)
             .where(FileContent.purpose == file_purpose)
             .where(FileContent.deleted == None))).all()
         return enrich_files(session, files, profile)
+
 
 @router.delete('/{file_id}')
 async def delete_file_by_id(file_id, profile_id: str = Depends(current_profile_id)):


### PR DESCRIPTION
File queries should be profile scoped - this also fixes test failure as it was seeing files from all profiles.