### PR TITLE
[api/nginx] fix(Websockets): Add the required settings for websocket-nginx. Test …

### DIFF
--- a/api/app/websocket_script_test.py
+++ b/api/app/websocket_script_test.py
@@ -8,6 +8,7 @@ To run use:
 $ cd api/app
 $ python ./websocket_script_test.py
 """
+
 # TODO: Make it flexible for different envs: dev, local, etc.
 # TODO: Delete even on fails all tested objects
 
@@ -58,7 +59,7 @@ class WebSocketTester:
                 raw: dict = json.loads(output_raw)
                 assert 'index' in raw
                 assert 'payload' in raw
-                #TODO: assert raw["index"] == stream_items[count_events]["index"]
+                # TODO: assert raw["index"] == stream_items[count_events]["index"]
                 count_events += 1
 
         assert page_sized_reads == int(
@@ -79,6 +80,15 @@ class WebSocketTester:
 
         async with httpx.AsyncClient() as client:
             page_size = 3
+            print(
+                "url:",
+                f"{self.http_uri}/readers/",
+                dict(
+                    json={'source': 'events', 'params': {'page_size': page_size}},
+                    headers=auth_header,
+                    timeout=self.timeout,
+                ),
+            )
             await client.post(
                 f"{self.http_uri}/readers/",
                 json={'source': 'events', 'params': {'page_size': page_size}},
@@ -129,10 +139,14 @@ def run_in_process(websocket_uri: str, http_uri: str, num_connections: int):
 if __name__ == "__main__":
     test_websocket_uri = "ws://localhost:50555/v1"
     test_http_uri = "http://localhost:50555/v1"
-    num_of_connections = 5
+    staging_websocket_uri = "ws://api-staging.mythica.ai/v1"
+    staging_http_uri = "http://api-staging.mythica.ai/v1"
+    num_of_connections = 1
 
     process = multiprocessing.Process(
-        target=run_in_process, args=(test_websocket_uri, test_http_uri, num_of_connections)
+        target=run_in_process,
+        # args=(test_websocket_uri, test_http_uri, num_of_connections),
+        args=(staging_websocket_uri, staging_http_uri, num_of_connections),
     )
     process.start()
     process.join()

--- a/api/nginx/conf/nginx-gke-staging.conf
+++ b/api/nginx/conf/nginx-gke-staging.conf
@@ -61,6 +61,25 @@ http {
             proxy_temp_file_write_size 64k;
         }
 
+        location /v1/readers/connect {
+            proxy_pass http://app.api-staging:80;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            proxy_connect_timeout 70;
+            proxy_send_timeout 90;
+            proxy_read_timeout 90;
+
+            proxy_buffer_size 4k;
+            proxy_buffers 4 32k;
+            proxy_busy_buffers_size 64k;
+            proxy_temp_file_write_size 64k;
+
+            client_max_body_size 100M;
+        }
+
         location  /v1  {
             proxy_pass http://app.api-staging:80;
 

--- a/api/nginx/conf/nginx-gke.conf
+++ b/api/nginx/conf/nginx-gke.conf
@@ -74,6 +74,25 @@ http {
             proxy_temp_file_write_size 64k;
         }
 
+        location /v1/readers/connect {
+            proxy_pass http://app.api:80;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            proxy_connect_timeout 70;
+            proxy_send_timeout 90;
+            proxy_read_timeout 90;
+
+            proxy_buffer_size 4k;
+            proxy_buffers 4 32k;
+            proxy_busy_buffers_size 64k;
+            proxy_temp_file_write_size 64k;
+
+            client_max_body_size 100M;
+        }
+
         location  /v1  {
             proxy_pass http://app.api:80;
 

--- a/api/nginx/conf/nginx-local.conf
+++ b/api/nginx/conf/nginx-local.conf
@@ -53,6 +53,26 @@ http {
             try_files $uri /index.html =404;
         }
 
+        location /v1/readers/connect {
+            proxy_pass http://app;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            proxy_connect_timeout 70;
+            proxy_send_timeout 90;
+            proxy_read_timeout 90;
+
+            proxy_buffer_size 4k;
+            proxy_buffers 4 32k;
+            proxy_busy_buffers_size 64k;
+            proxy_temp_file_write_size 64k;
+
+            client_max_body_size 100M;
+        }
+
+
         location  /v1  {
             proxy_pass http://app;
 


### PR DESCRIPTION
…the api/app/websocket_script_test.py.
![image](https://github.com/user-attachments/assets/35acd85f-eeb1-4a0c-aaaa-b42a987a53ef)
The staging backend redirects file processing requests to production via the NatsAdapter. This may not be an issue since the staging packager is currently non-functional. Still, staging and prod use the same bucket (**_translating gcs://gke-us-central1.mythica-public-files:66523c61f1424879f30eff0807f562cb7a6d8c8c.hda_**) (assuming my understanding of the NatsAdapter is correct). 
Regardless, everything seems to be working as expected.
![image](https://github.com/user-attachments/assets/3ba9125c-962c-4f24-8c6b-5aff1927d3cd)
![image](https://github.com/user-attachments/assets/751131c7-45a3-4735-afbd-757c1bc904ae)
