### PR TITLE
[automation] Expose mesh output file format option to clients

### DIFF
--- a/api/canary/job_canary.py
+++ b/api/canary/job_canary.py
@@ -102,7 +102,8 @@ def request_job(endpoint: str, headers: str, job_def_id: str, mesh_file_id: str)
     body = {
         "job_def_id": job_def_id,
         "params": {
-            "input0": { "file_id": mesh_file_id }
+            "input0": { "file_id": mesh_file_id },
+            "format": "usdz"
         }
     }
 

--- a/automation/houdini/automation/generate_job_defs.py
+++ b/automation/houdini/automation/generate_job_defs.py
@@ -43,7 +43,6 @@ def set_config_params(param_spec: ParameterSpec, hda_file_id: str, index: int):
     )
     param_spec.params['format'] = StringParameterSpec(
         label='Format', 
-        constant=True, 
         default='usdz'
     )
 

--- a/automation/houdini/automation/generate_mesh.py
+++ b/automation/houdini/automation/generate_mesh.py
@@ -131,11 +131,13 @@ def generate_mesh_impl(
         usdz_node.parm("outfile1").set(output_zip_file_path)
         usdz_node.parm("execute").pressButton()
 
+        output_file_path = output_zip_file_path
+
     hou.hda.uninstallFile(hda_path)
 
     mdarol.end_houdini(hip)
 
-    return output_zip_file_path
+    return output_file_path
 
 
 class ExportMeshRequest(ParameterSet):


### PR DESCRIPTION
Jobs were currently forced to always return USDZ format. Exposing this option to clients to allow them to specify FBX. 

This is needed to support porting the current version of Max/Liam cave generation HDA. It is currently implemented using FBX.