### PR TITLE
[ripple] Report job failure to clients more cleanly

### DIFF
--- a/libs/python/ripple/ripple/automation.py
+++ b/libs/python/ripple/ripple/automation.py
@@ -226,6 +226,9 @@ class ResultPublisher:
 
 
         def upload_file(token: str, file_path: str) -> Optional[str]:
+            if not os.path.exists(file_path):
+                return None
+
             file_id = None
             try:
                 with open(file_path, 'rb') as file:


### PR DESCRIPTION
A job that fails due to an HDA dependency issue would throw an exception and then never mark the job as completed. This would cause the client to wait forever waiting for the job to finish.

Fixed by making it mark the job as "completed" if an exception occurs. We may want to change this completed flag to be an error code to be more explicit here. For now I am considering "completed" to just mean that the job has finished processing, and the client will need to inspect the results items to determine if it was successful or not.

I've also fixed the issue that was causing it to throw an exception in this case. It will now cleanly report back to the client that it failed to generate any result mesh by sending back a mesh fileId of "None".

I also plan to add a timeout on the client to prevent any similar issues in the future from causing the client to get into a bad state.