### PR TITLE
[houdini] Prevent hidden parameters from appearing in Job Definitions specs

### DIFF
--- a/automation/houdini/darol-plugin/scripts/python/mythica/network.py
+++ b/automation/houdini/darol-plugin/scripts/python/mythica/network.py
@@ -137,7 +137,7 @@ def get_node_type(node_type, include_code = True):
     # Loop through all the parameters of the node for defaults and to
     # sort out ramp parms. 
     for parmtemp in node_type.parmTemplates():
-        if _isValueParm(parmtemp):
+        if _isValueParm(parmtemp) and not parmtemp.isHidden():
             defaults = _get_parm_defaults(parmtemp)
             if defaults is not None:
                 nt["defaults"][parmtemp.name()] = defaults


### PR DESCRIPTION
The rockify tool uses some hidden parameters for internal implementation reasons. Preventing these from leaking into the public interface.