### PR TITLE
[houdini] Disable writing HIP file to avoid performance stalls

### DIFF
--- a/automation/houdini/automation/generate_mesh.py
+++ b/automation/houdini/automation/generate_mesh.py
@@ -59,7 +59,8 @@ def generate_mesh_impl(
     output_file_name = os.path.basename(hda_path)
     hip = os.path.join(working_dir, f'export_mesh_{output_file_name}.hip')
 
-    mdarol.start_houdini(hip)
+    log.info("Clearing scene")
+    hou.hipFile.clear(suppress_save_prompt=True)
 
     log.info("Intalling HDA")
     hou.hda.installFile(hda_path, force_use_assets=True)
@@ -151,8 +152,6 @@ def generate_mesh_impl(
     log.info("Unintalling HDA")
     hou.hda.uninstallFile(hda_path)
     log.info("Unintalling HDA completed")
-
-    mdarol.end_houdini(hip)
 
     return output_file_path
 


### PR DESCRIPTION
I am investigating a 1 second performance stall that seem to be manifesting at different API calls on different runs.

From testing, it seems like removing this HIP file write appears to remove the issue. This is a file we just throw away after the automation runs so removing it to not write out in the first place.