### PR TITLE
[houdini] Fix shutting down container causing license to leak

### DIFF
--- a/automation/houdini/houdini.sh
+++ b/automation/houdini/houdini.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 export PATH=/opt/houdini/build/bin:$PATH
 hserver -S https://www.sidefx.com/license/sesinetd
-hython workers.py || true
-hserver -Q
+hython workers.py &
+
+# Release Houdini licenses held by this worker
+cleanup() {
+    printf "Received SIGTERM, cleaning up...\n"
+    hserver -Q
+    printf "Finished cleanup.\n"
+}
+
+trap cleanup TERM
+
+while true; do
+    sleep 1
+done


### PR DESCRIPTION
Porting over fix that we had used in the deprecated houdini-worker