### PR TITLE
[api/app] Generate job definitions from hdalc files

### DIFF
--- a/api/app/db/index.py
+++ b/api/app/db/index.py
@@ -60,7 +60,7 @@ def update(ctx: RequestContext) -> Tuple[str, str]:
         event_id = event_seq_to_id(event_seq)
 
         # Create a new NATS event
-        if ctx.extension in ['hda', 'hdalc']:
+        if ctx.extension in ('hda', 'hdalc'):
             parameter_set = ParameterSet(
                 hda_file = FileParameter(file_id=file_id)
             )


### PR DESCRIPTION
I discussed this with Slater. Long term we should look into something similar to the Orbolt service where they have a process for converting 'hdanc'/'hdalc' files into 'hda'. Currently if we operate on 'hdalc'/'hdanc' directly it may run into some functionality restrictions in Houdini.

In my rough testing I haven't run into any of those functionality restrictions with these basic mesh generation HDAs. For the short term we can just allow us system to operate on these other file types.