### PR TITLE
[api/app] Generate job defs for hdanc files

### DIFF
--- a/api/app/db/index.py
+++ b/api/app/db/index.py
@@ -60,7 +60,7 @@ def update(ctx: RequestContext) -> Tuple[str, str]:
         event_id = event_seq_to_id(event_seq)
 
         # Create a new NATS event
-        if ctx.extension in ('hda', 'hdalc'):
+        if ctx.extension in ('hda', 'hdalc', 'hdanc'):
             parameter_set = ParameterSet(
                 hda_file = FileParameter(file_id=file_id)
             )


### PR DESCRIPTION
We may want to store this list of extension types in some shared place.

We may also want to include the older deprecated extensions: "otl","otllc","otlnc"

These consideration will likely become irrelevant soon though once we change this to the better flow of converting all these file types to "hda" before processing them.