### PR TITLE
[ripple] Workaround assert on script populated menu parameters

### DIFF
--- a/libs/python/ripple/ripple/compile/rpsc.py
+++ b/libs/python/ripple/ripple/compile/rpsc.py
@@ -51,7 +51,10 @@ def compile_interface(interface_data: str) -> ParameterSpec:
         elif value['type'] == 'Toggle':
             param = BoolParameterSpec(**value)
         elif value['type'] == 'Menu':
-            param = parse_menu_parameter(value)
+            if 'menu_items' in value and 'menu_labels' in value:
+                param = parse_menu_parameter(value)
+            else:
+                continue
         else:
             continue
 

--- a/libs/python/ripple/tests/test_params.py
+++ b/libs/python/ripple/tests/test_params.py
@@ -185,6 +185,22 @@ def test_param_compile():
     assert compiled.params['test_enum'].values[0].label == "A"
     assert compiled.params['test_enum'].default == "a"
 
+    # Empty enum test
+    data = """
+    {
+        "defaults": {
+            "test_enum": {
+                "type": "Menu",
+                "label": "Test Enum",
+                "default": 0
+            }
+        },
+        "inputLabels": []
+    }
+    """
+    compiled = compile_interface(data)
+    assert len(compiled.params) == 0
+
     # File test
     data = """
     {


### PR DESCRIPTION
This is a workaround to fix the TreeFromShape package: https://api.mythica.ai/package-view/asset_4B2F5juyEPYoqoR7Hyed2tiFo6MM/versions/1.0.0

This HDA uses a menu parameter with items populated by a script. We don't currently support this, so when we export this interface data from Houdini it looks like a Menu parameter with 0 options. This was causing an assert in the compiler logic.

Working around for now by ignoring Menu parameters with no entries.

This parameter was part of pattern of defining presets inside the HDA. Excluding this parameter will have the impact of not being able to switch between presets in the Unreal UI. However this concept of presets is something already on our list to address and define best practices around. So will hopefully revisit this soon-ish.