### PR TITLE
[ripple, automation] Only generate job defs for SOP type nodes

### DIFF
--- a/automation/houdini/automation/generate_job_defs.py
+++ b/automation/houdini/automation/generate_job_defs.py
@@ -61,6 +61,10 @@ def generate_job_defs(request: GenerateJobDefRequest, responder: ResultPublisher
     type_infos = extract_node_type_info(hda_file.file_path)
     ret = []
     for index, type_info in enumerate(type_infos):
+        category = type_info['category']
+        if category != 'SOP':
+            continue
+
         param_spec = compile_interface(json.dumps(type_info, indent=2))
         set_config_params(param_spec, hda_file.file_id, index)
 


### PR DESCRIPTION
This fixes an issue with the SimpleTrees package: https://api.mythica.ai/package-view/asset_JPvqMSvcwhU5srMWC2ADTgG1e9k/versions/1.0.0

The HDA contains a list of recipes to define it's presets. Recipes are defined with a "DATA" node type in the HDA. We were not filtering what node categories we were generating job definitions for, so it was improperly generating job defs for each of these recipes node types. This was creating a lot of extra job definitions that wouldn't work. This change will also help filter out other invalid node types, as these generate_mesh automation are only intended to work with SOP.

If we DO decide we want separate job definitions for each of these presets, we would want to do this in a different way. The job definition would still need to reference the primary node type, and we would just change the preset parameter on that node.