### PR TITLE
[ripple, automation] Support for integer parameter menus

### DIFF
--- a/automation/houdini/darol-plugin/scripts/python/mythica/network.py
+++ b/automation/houdini/darol-plugin/scripts/python/mythica/network.py
@@ -938,7 +938,7 @@ def _get_parm_defaults(parmtemp):
     if hasattr(parmtemp, "maxValue"):
         _parm["max"] = parmtemp.maxValue()
 
-    if isinstance(parmtemp, hou.MenuParmTemplate) or isinstance(parmtemp, hou.StringParmTemplate):
+    if isinstance(parmtemp, hou.MenuParmTemplate) or isinstance(parmtemp, hou.StringParmTemplate) or isinstance(parmtemp, hou.IntParmTemplate):
         menu_items = parmtemp.menuItems()
         menu_labels = parmtemp.menuLabels()
         if len(menu_items) > 0 and len(menu_labels) > 0:

--- a/libs/python/ripple/ripple/compile/rpsc.py
+++ b/libs/python/ripple/ripple/compile/rpsc.py
@@ -40,7 +40,10 @@ def compile_interface(interface_data: str) -> ParameterSpec:
     
     for name, value in data['defaults'].items():
         if value['type'] == 'Int':
-            param = IntParameterSpec(**value)
+            if 'menu_items' in value and 'menu_labels' in value:
+                param = parse_menu_parameter(value)
+            else:
+                param = IntParameterSpec(**value)
         elif value['type'] == 'Float':
             param = FloatParameterSpec(**value)
         elif value['type'] == 'String':

--- a/libs/python/ripple/tests/test_params.py
+++ b/libs/python/ripple/tests/test_params.py
@@ -162,6 +162,29 @@ def test_param_compile():
     assert compiled.params['test_enum'].values[0].label == "A"
     assert compiled.params['test_enum'].default == "a"
 
+    # Int enum test
+    data = """
+    {
+        "defaults": {
+            "test_enum": {
+                "type": "Int",
+                "label": "Test Enum",
+                "menu_items": ["0", "1", "2"],
+                "menu_labels": ["A", "B", "C"],
+                "default": 0
+            }
+        },
+        "inputLabels": []
+    }
+    """
+    compiled = compile_interface(data)
+    assert len(compiled.params) == 1
+    assert isinstance(compiled.params['test_enum'], EnumParameterSpec)
+    assert len(compiled.params['test_enum'].values) == 3
+    assert compiled.params['test_enum'].values[0].name == "0"
+    assert compiled.params['test_enum'].values[0].label == "A"
+    assert compiled.params['test_enum'].default == "0"
+
     # Bad enum default test
     data = """
     {


### PR DESCRIPTION
This fixes an issue with the SimpleTrees package: https://api.mythica.ai/package-view/asset_JPvqMSvcwhU5srMWC2ADTgG1e9k/versions/1.0.0

There is yet another parameter type that I didn't realize supported a menu based display. This change will update integer parameters with menu data to be parsed as an enum field. This cause the parameter to display as a dropdown with proper label names.