### PR TITLE
[api/app] Disable support for hdanc generation jobs

### DIFF
--- a/api/app/db/index.py
+++ b/api/app/db/index.py
@@ -60,7 +60,7 @@ def update(ctx: RequestContext) -> Tuple[str, str]:
         event_id = event_seq_to_id(event_seq)
 
         # Create a new NATS event
-        if ctx.extension in ('hda', 'hdalc', 'hdanc'):
+        if ctx.extension in ('hda', 'hdalc'):
             parameter_set = ParameterSet(
                 hda_file = FileParameter(file_id=file_id)
             )


### PR DESCRIPTION
Backing out this PR: https://github.com/MythicaAI/infra/pull/408

When processing an hdanc, it will drop the Houdini session into a non-commercial mode. It will be stuck in this mode until the session is restarted. This mode restricts some functionality like FBX exporting, which is causing the rockify tool to break.

Houdini does seem to support USD export when in non-commercial mode. So it is possible to work around this by restarting the hython process when necessary to not break the rockify tool. However going to disable hdanc for now while we investigate the best solution here.

Allowing the system to process hdalc appears fine for now. There doesn't appear to be the same functionality restrictions with the Limited Commercial mode that converts the process into.