### PR TITLE
[automation] Upgrade Houdini worker memory 2GB -> 6GB

### DIFF
--- a/automation/k8s/deployment_houdini_nogpu.yaml
+++ b/automation/k8s/deployment_houdini_nogpu.yaml
@@ -33,9 +33,9 @@ spec:
             limits:
               cpu: 500m
               ephemeral-storage: 1Gi
-              memory: 4Gi
+              memory: 6Gi
             requests:
               cpu: 500m
               ephemeral-storage: 1Gi
-              memory: 4Gi
+              memory: 6Gi
       restartPolicy: Always


### PR DESCRIPTION
Both the rockify and SimpleTree tools have been causing the server to crash. It appears the cause of the crash is an out of memory error. From testing updating it to ~6GB appears to be enough to fix it.

Updating the houdini deployment config from 2GB -> 6GB ram. The other cpu/storage settings match what the defaults were just to make it explicit in the config.

However when actually deploying the container, it seems to allocate it with a CPU higher than the requested spec.
![image](https://github.com/user-attachments/assets/6432b1cf-df12-43b2-b436-1916ab74047e)
