### PR TITLE
[fix] remove images domains

### DIFF
--- a/api/helm/.gitignore
+++ b/api/helm/.gitignore
@@ -1,0 +1,1 @@
+api/values-images.yaml

--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -14,8 +14,6 @@ domains:
   - oss.mythica.gg
   - api.mythica.ai
   - api.mythica.gg
-  - images.mythica.ai
-  - images.mythica.gg
   - dex.mythica.ai
   - dex.mythica.gg
 


### PR DESCRIPTION
We are not supporting routes from the images.mythica domains now.