### PR TITLE
[fix] address win32 docker compose vol mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ __pycache__
 **/output
 
 *.local
+
+testing/mnt/os_mount_paths.env

--- a/testing/storage/docker-compose.yaml
+++ b/testing/storage/docker-compose.yaml
@@ -70,19 +70,13 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: "../mnt/pgdata"
+      device: ${PGDATA_PATH}
   blockstore:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: "../mnt/blockstore"
-  mldata:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: "../mnt/mldata"
+      device: ${BLOCKSTORE_PATH}
 
 networks:
   storage:


### PR DESCRIPTION
Docker mounts were failing under windows as the local driver wants absolute paths in windows path format. This change generates an env file from the docker startup tasks with absolute paths per environment and passes that to the volume driver.