### PR TITLE
[jungle3] Various improvements for AssetEdit

### DIFF
--- a/sites/jungle3/public/locales/en/common.json
+++ b/sites/jungle3/public/locales/en/common.json
@@ -5,7 +5,7 @@
     "published": "Published",
     "draft": "Draft",
     "name": "Name",
-    "desc": "Description",
+    "description": "Description",
     "sortingPanel": {
       "options": [
         {
@@ -46,7 +46,8 @@
     "chooseExistingOrg": "Choose an existing org...",
     "filloutDesc": "Fill out a description",
     "version": "Version",
-    "publicView": "Public view"
+    "publicView": "Public view",
+    "deps": "Dependencies"
   },
   "myUploads": {
     "title": "Your uploads",

--- a/sites/jungle3/public/locales/es/common.json
+++ b/sites/jungle3/public/locales/es/common.json
@@ -46,7 +46,8 @@
     "chooseExistingOrg": "Elige una org existente...",
     "filloutDesc": "Rellena una descripción",
     "version": "Versión",
-    "publicView": "Vista pública"
+    "publicView": "Vista pública",
+    "deps": "Dependencias"
   },
   "myUploads": {
     "title": "Tus subidas",

--- a/sites/jungle3/src/components/AssetEdit/AssetEditDeps/index.tsx
+++ b/sites/jungle3/src/components/AssetEdit/AssetEditDeps/index.tsx
@@ -1,0 +1,45 @@
+import { Card, Chip, FormLabel, Typography } from "@mui/joy";
+import { Dependency } from "@store/assetVersionStore";
+import React from "react";
+
+type Props = {
+  deps: Dependency[];
+};
+
+export const AssetEditDeps: React.FC<Props> = ({ deps }) => {
+  return (
+    <div>
+      <FormLabel sx={{ mb: "8px", ml: "4px" }}>
+        <Typography variant="soft" level="title-md" fontWeight="bold">
+          Dependencies
+        </Typography>
+      </FormLabel>
+      {deps && deps.length > 0 ? (
+        deps.map((dep) => (
+          <Card
+            size="sm"
+            sx={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <Typography fontSize={14}>{dep.file_name}</Typography>
+
+            <Chip
+              key={dep.version.join(".")}
+              variant="soft"
+              color="primary"
+              size="lg"
+              sx={{ borderRadius: "xl" }}
+            >
+              {dep.version.join(".")}
+            </Chip>
+          </Card>
+        ))
+      ) : (
+        <Typography textAlign="start">No dependencies yet.</Typography>
+      )}
+    </div>
+  );
+};

--- a/sites/jungle3/src/components/AssetEdit/AssetEditVersionDropdown.tsx
+++ b/sites/jungle3/src/components/AssetEdit/AssetEditVersionDropdown.tsx
@@ -10,8 +10,6 @@ import {
   ListItemButton,
   ListItem,
   ListItemDecorator,
-  Switch,
-  Typography,
   Stack,
 } from "@mui/joy";
 import {
@@ -39,14 +37,12 @@ export type VersionTuple = [number, number, number];
 export const AssetEditVersionDropdown = () => {
   const { version: paramVersion } = useParams();
   const navigate = useNavigate();
-  const { asset_id, version, published, updateVersion } =
-    useAssetVersionStore();
+  const { asset_id, version, updateVersion } = useAssetVersionStore();
   const { addError, addWarning } = useStatusStore();
   const [availableVersions, setAvailableVersions] = useState<
     AssetVersionResponse[]
   >([]);
   const { t } = useTranslation();
-  // const { mutate: deleteAssetVersion } = useDeleteAsset();
 
   // version sanitizing state, should only be populated by the sanitizeVersion() function
   const [sanitizedVersion, setSanitizedVersion] = useState<number[]>([0, 0, 0]);
@@ -199,44 +195,6 @@ export const AssetEditVersionDropdown = () => {
           ""
         )}
       </FormControl>
-      <Stack gap="2px">
-        <FormControl orientation={"horizontal"}>
-          <Typography
-            component="span"
-            level="body-md"
-            sx={{
-              textAlign: "right",
-              alignItems: "center",
-              pr: "5px",
-              width: "auto",
-            }}
-          >
-            {published ? t("common.published") : t("common.draft")}
-          </Typography>
-          <Switch
-            checked={published}
-            onChange={(event) =>
-              updateVersion({ published: event.target.checked })
-            }
-            color={published ? "success" : "neutral"}
-            sx={{ flex: 1 }}
-          />
-          <input type="hidden" name="published" value={published.toString()} />
-        </FormControl>
-        {/* <Button
-          variant="outlined"
-          color="neutral"
-          sx={{ width: "fit-content" }}
-          onClick={() =>
-            deleteAssetVersion({
-              assetId: asset_id,
-              assetVersion: paramVersion as string,
-            })
-          }
-        >
-          <Trash />
-        </Button> */}
-      </Stack>
     </Stack>
   );
 };

--- a/sites/jungle3/src/components/AuthHeader.tsx
+++ b/sites/jungle3/src/components/AuthHeader.tsx
@@ -128,7 +128,12 @@ export const AuthHeader = () => {
 
   return (
     <Stack>
-      <Stack direction="row" width="100%" justifyContent="space-between">
+      <Stack
+        direction="row"
+        width="100%"
+        justifyContent="space-between"
+        p="12px 16px 0"
+      >
         <Link to={"/"}>
           <Stack direction="row" gap="10px">
             <Box

--- a/sites/jungle3/src/components/Footer.tsx
+++ b/sites/jungle3/src/components/Footer.tsx
@@ -1,0 +1,11 @@
+import { Stack, Typography } from "@mui/joy";
+
+export const Footer = () => {
+  return (
+    <Stack>
+      <Typography fontSize={18} fontWeight={600}>
+        Copyright 2024-2025 Mythica
+      </Typography>
+    </Stack>
+  );
+};

--- a/sites/jungle3/src/components/common/DeleteModal/index.tsx
+++ b/sites/jungle3/src/components/common/DeleteModal/index.tsx
@@ -13,19 +13,21 @@ type Props = {
   open: boolean;
   handleConfirm: () => void;
   handleClose?: () => void;
+  title?: string;
 };
 
 export const DeleteModal: React.FC<Props> = ({
   open,
   handleClose,
   handleConfirm,
+  title = "Are you sure you want to delete this item?",
 }) => {
   return (
     <Modal open={open} onClose={handleClose}>
       <ModalDialog>
         <ModalClose />
         <Card>
-          <Typography>Are you sure you want to delete this item?</Typography>
+          <Typography>{title}</Typography>
         </Card>
         <Stack
           direction={"row"}

--- a/sites/jungle3/src/pages/Dashboard.tsx
+++ b/sites/jungle3/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { DashboardCard } from "@components/DashboardCard";
-import { Card, CircularProgress, Stack, Typography, Grid } from "@mui/joy";
+import { Card, CircularProgress, Stack, Typography, Grid, Box } from "@mui/joy";
 import { useGetOwnedPackages } from "@queries/packages";
 import { useGetPendingUploads } from "@queries/uploads";
 import { useGlobalStore } from "@store/globalStore";
@@ -15,11 +15,15 @@ const Dashboard = () => {
   const { data: uploads, isLoading: isUploadsLoading } = useGetPendingUploads();
   const { t } = useTranslation();
 
+  const uniqueOrgs = [
+    ...new Map(orgRoles.map((org) => [org.org_id, org])).values(),
+  ];
+
   if (!profile || isPackagesLoading || isUploadsLoading)
     return <CircularProgress />;
 
   return (
-    <div>
+    <Box p="0 16px">
       <Card sx={{ mb: "20px" }}>
         <Stack
           direction="row"
@@ -44,7 +48,7 @@ const Dashboard = () => {
         <Grid md={4} xs={6}>
           <DashboardCard
             title={t("common.profileMenu.myOrgs")}
-            textContent={orgRoles?.length ?? "0"}
+            textContent={uniqueOrgs?.length ?? "0"}
             url="/orgs"
           />
         </Grid>
@@ -56,7 +60,7 @@ const Dashboard = () => {
           />
         </Grid>
       </Grid>
-    </div>
+    </Box>
   );
 };
 

--- a/sites/jungle3/src/pages/ProfileSettings.tsx
+++ b/sites/jungle3/src/pages/ProfileSettings.tsx
@@ -46,6 +46,10 @@ const ProfileSettings = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
+  const uniqueOrgs = [
+    ...new Map(orgRoles.map((org) => [org.org_id, org])).values(),
+  ];
+
   const handleError = (err: AxiosError) => {
     addError(translateError(err));
     extractValidationErrors(err).map((msg) => addWarning(msg));
@@ -188,7 +192,7 @@ const ProfileSettings = () => {
         </Typography>
         <CardContent>
           <List marker="disc">
-            {orgRoles.map((role) => (
+            {uniqueOrgs.map((role) => (
               <ListItem key={role.org_id} sx={{ textAlign: "start" }}>
                 {role.org_name}
               </ListItem>

--- a/sites/jungle3/src/queries/packages/index.ts
+++ b/sites/jungle3/src/queries/packages/index.ts
@@ -92,22 +92,14 @@ export const useUpdateAsset = () => {
 
 export const useDeleteAsset = () => {
   const queryClient = useQueryClient();
-  let assetId = "";
 
   return useMutation({
-    mutationFn: async (deleteRequest: {
-      assetId: string;
-      assetVersion: string;
-    }) => {
-      assetId = deleteRequest.assetId;
+    mutationFn: async (assetId: string) => {
       return await api.del({
-        path: `${PackagesApiPath.ASSETS}/${deleteRequest.assetId}${PackagesApiPath.VERSIONS}/${deleteRequest.assetVersion}`,
+        path: `${PackagesApiPath.ASSETS}/${assetId}`,
       });
     },
     onSuccess: async () => {
-      queryClient.invalidateQueries({
-        queryKey: [PackagesQuery.ASSETS, assetId],
-      });
       queryClient.invalidateQueries({ queryKey: [PackagesQuery.OWNED] });
     },
   });

--- a/sites/jungle3/src/stores/assetVersionStore.ts
+++ b/sites/jungle3/src/stores/assetVersionStore.ts
@@ -11,6 +11,15 @@ type Tag = {
   tag_name: string;
 };
 
+export type Dependency = {
+  asset_id: string;
+  content_hash: string;
+  file_name: string;
+  package_id: string;
+  size: number;
+  version: number[];
+};
+
 interface AssetVersion {
   asset_id: string;
   org_id: string;
@@ -26,6 +35,7 @@ interface AssetVersion {
   updated: string;
   files: AssetVersionContentMap;
   thumbnails: AssetVersionContentMap;
+  dependencies: Dependency[];
   links: Link[];
   initialTag: Tag;
   tag: string;
@@ -40,6 +50,7 @@ interface AssetVersion {
   removeThumbnail: (file_id: string) => AssetVersionContentMap;
   removeThumbnails: () => AssetVersionContentMap;
   setLinks: (links: Link[]) => Link[];
+  setDeps: (deps: Dependency[]) => Dependency[];
   setInitialTag: (tag: Tag) => Tag;
   setTag: (tag: string) => string;
   setCustomTag: (tag: string) => string;
@@ -137,6 +148,10 @@ export const useAssetVersionStore = create<AssetVersion>((set, get) => ({
   setLinks: (data: Link[]) => {
     set(() => ({ links: data }));
     return get().links;
+  },
+  setDeps: (data: Dependency[]) => {
+    set(() => ({ dependencies: data }));
+    return get().dependencies;
   },
   setInitialTag: (value: Tag) => {
     set(() => ({ initialTag: value }));

--- a/sites/jungle3/src/types/apiTypes.ts
+++ b/sites/jungle3/src/types/apiTypes.ts
@@ -88,6 +88,9 @@ export interface AssetVersionContent {
   file_name: string;
   content_hash: string;
   size: number;
+  asset_id?: string;
+  package_id?: string;
+  version?: number[];
 }
 
 export type AssetVersionContentMap = {


### PR DESCRIPTION
Lot of improvements from miro board, the biggest ones are:
- Removed 'publish' toggle, now we use updated buttons (Save draft/Publish)
- Delete functionality 
- Dependencies tab 

Bunch of minor fixes (paddings/margins, translation keys, etc.)