### PR TITLE
[telemetry]: Decrease the exporting interval to fix resource is exhasted.

### DIFF
--- a/api/helm/otel/templates/otel-collector-deployment.yaml
+++ b/api/helm/otel/templates/otel-collector-deployment.yaml
@@ -17,11 +17,11 @@ spec:
         - name: otel-collector
           resources:
             requests:
-              memory: "512Mi"
-              cpu: "250m"
+              memory: "128Mi"
+              cpu: "50m"
             limits:
-              memory: "1024Mi"
-              cpu: "500m"
+              memory: "256Mi"
+              cpu: "100m"
           image: signoz/signoz-otel-collector
           args:
             - "--config=/etc/otel-collector-config.yaml"

--- a/libs/python/ripple/ripple/config.py
+++ b/libs/python/ripple/ripple/config.py
@@ -88,7 +88,7 @@ def configure_telemetry(telemetry_endpoint: str, telemetry_insecure: bool, heade
         insecure=telemetry_insecure,
         headers=headers,
     )
-    reader = PeriodicExportingMetricReader(metric_exporter)
+    reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=500)
     meterProvider = MeterProvider(metric_readers=[reader], resource=resource)
     metrics.set_meter_provider(meterProvider)
 


### PR DESCRIPTION
Reduce resource for telemetry collector as it uses less than is declared, but decrease the exporting interval.