### PR TITLE
fix([telemetry]): Increase resources for telemetry containers.

### DIFF
--- a/.github/workflows/helm-deploy-staging.yaml
+++ b/.github/workflows/helm-deploy-staging.yaml
@@ -82,9 +82,12 @@ jobs:
           helm upgrade --namespace api-staging -f api/helm/api/values-staging.yaml -f api/helm/api/values-images.yaml api-staging api/helm/api
           echo "## Upgraded image versions" >> $GITHUB_STEP_SUMMARY
           cat api/helm/api/values-images.yaml >> $GITHUB_STEP_SUMMARY
+          helm upgrade otel-release-k8s-infra ./api/helm/otel -f ./api/helm/otel/values.yaml -n default
 
       - name: Rollout deployments
         run: |
+          kubectl rollout restart deployment/otel-agent -n default
+          kubectl rollout restart deployment/otel-collector -n default
           kubectl rollout restart deployment/app -n api-staging
           kubectl rollout restart deployment/packager -n api-staging
           kubectl rollout restart deployment/lets-encrypt -n api-staging

--- a/api/helm/otel/templates/otel-agent-config.yaml
+++ b/api/helm/otel/templates/otel-agent-config.yaml
@@ -10,10 +10,12 @@ data:
         config:
           scrape_configs:
             - job_name: 'nginx'
+              scrape_interval: 15s
               static_configs:
                 - targets: ['web-front:80']
                   metrics_path: '/nginx_status'
             - job_name: 'app'
+              scrape_interval: 15s
               static_configs:
                 - targets: ['app:5555']
                   metrics_path: '/metrics'

--- a/api/helm/otel/templates/otel-collector-config.yaml
+++ b/api/helm/otel/templates/otel-collector-config.yaml
@@ -25,31 +25,29 @@ data:
                 - targets: [localhost:8888]
 
     exporters:
-      logging:
-        verbosity: detailed
       otlp:
         endpoint: ingest.us.signoz.cloud:443
         tls:
           insecure: false
-        timeout: 10s
+        timeout: 30s
         headers:
           "signoz-access-token": ${SIGNOZ_API_KEY}
 
     processors:
-        batch:
-          timeout: 5s
-          send_batch_size: 1024
-          send_batch_max_size: 8192
+      batch:
+        timeout: 5s
+        send_batch_size: 512
+        send_batch_max_size: 10000
 
     service:
       pipelines:
         logs:
           receivers: [otlp]
+          processors: [batch]
           exporters: [otlp]
         metrics:
           receivers: [otlp]
-          processors: [batch]
-          exporters: [logging, otlp]
+          exporters: [otlp]
         traces:
           receivers: [otlp]
           processors: [batch]

--- a/api/helm/otel/templates/otel-collector-deployment.yaml
+++ b/api/helm/otel/templates/otel-collector-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-collector
   namespace: default
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: otel-collector
@@ -17,12 +17,12 @@ spec:
         - name: otel-collector
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "50m"
-            limits:
               memory: "256Mi"
-              cpu: "100m"
-          image: signoz/signoz-otel-collector
+              cpu: "2000m"
+            limits:
+              memory: "512Mi"
+              cpu: "4000m"
+          image: signoz/signoz-otel-collector:latest
           args:
             - "--config=/etc/otel-collector-config.yaml"
           env:

--- a/libs/python/ripple/ripple/config.py
+++ b/libs/python/ripple/ripple/config.py
@@ -11,7 +11,11 @@ from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk._logs.export import (
+    BatchLogRecordProcessor,
+    ConsoleLogExporter,
+    SimpleLogRecordProcessor,
+)
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import OTELResourceDetector, Resource
@@ -103,6 +107,10 @@ def configure_telemetry(telemetry_endpoint: str, telemetry_insecure: bool, heade
         headers=headers,
     )
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    if ripple_config().mythica_environment == "debug":
+        logger_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(ConsoleLogExporter())
+        )
 
     otel_log_handler = LoggingHandler(level=logging.INFO)
     logger.addHandler(otel_log_handler)


### PR DESCRIPTION
For status - Exhausted - It happened only for prod, seems the setting up export_interval_millis in staging helped. Anyway, I restarted the pods and will inspect it.
For status - Unavailable - it happened because of resources:
![image](https://github.com/user-attachments/assets/be34a12b-5706-43f8-8ad7-7992d7292fdc)

From docs the batching is not used for metrics it sends metrics for each request.
Add the scrape_interval to agent.
Restart pods.