### PR TITLE
[api/jobs] Fix invalid sequence number error in GET /definitions

### DIFF
--- a/api/app/routes/jobs/jobs.py
+++ b/api/app/routes/jobs/jobs.py
@@ -148,7 +148,8 @@ async def list_definitions() -> list[JobDefinitionModel]:
         job_defs = session.exec(select(JobDefinition)).all()
         return [JobDefinitionModel(
             job_def_id=job_def_seq_to_id(job_def.job_def_seq),
-            owner_id=profile_seq_to_id(job_def.owner_seq), **job_def.model_dump())
+            owner_id=profile_seq_to_id(job_def.owner_seq) if job_def.owner_seq is not None else None, 
+            **job_def.model_dump())
             for job_def in job_defs
         ]
 

--- a/api/app/tests/test_jobs.py
+++ b/api/app/tests/test_jobs.py
@@ -58,6 +58,19 @@ def test_create_update(client, api_base, create_profile):
     o = munchify(r.json())
     job_def_id = o.job_def_id
 
+    # Create a job definition with no owner
+    r = client.post(f'{api_base}/jobs/definitions',
+                    json={
+                        'job_type': 'houdini::/mythica/generate_mesh',
+                        'name': 'Generate Cactus 2',
+                        'description': 'Generates a cactus mesh',
+                        'params_schema': {
+                            'params': {}
+                        }
+                    })
+    assert_status_code(r, HTTPStatus.CREATED)
+    o = munchify(r.json())
+
     # Get job definition from list
     r = client.get(f'{api_base}/jobs/definitions', headers=headers)
     assert_status_code(r, HTTPStatus.OK)


### PR DESCRIPTION
This is the fix for the current canary failure:
Test failed: 400 Client Error: Bad Request for url: http://app/v1/jobs/definitions

This was related to #601. We were not properly handing job_defs that don't have an owner (eg. all the data before this PR went in).