### PR TITLE
[packager] Fix missing NATS_ENDPOINT config

### DIFF
--- a/api/helm/api/templates/deployment-packager.yaml
+++ b/api/helm/api/templates/deployment-packager.yaml
@@ -47,6 +47,8 @@ spec:
                 secretKeyRef:
                   name: packager-secrets
                   key: MYTHICA_API_KEY
+            - name: NATS_ENDPOINT
+              value: nats://nats.nats:4222
           volumeMounts:
             - name: ephemeral-packaged-content
               mountPath: /tmp


### PR DESCRIPTION
I recently changed the packager to start sending NATS event: #640 

This was failing to connect to the NATS server. From talking to Pedro I think this is likely the fix looking at how the app deployment is setup.