### PR TITLE
[api/app, ripple] Fix errors with job_def publishing

### DIFF
--- a/api/app/routes/jobs/jobs.py
+++ b/api/app/routes/jobs/jobs.py
@@ -135,7 +135,7 @@ async def define_new(
                 entry_point=request.source.entry_point,
                 job_def_seq=job_def_seq
             )
-            session.add(asset_version_entry_point)
+            session.merge(asset_version_entry_point)
             session.commit()
 
         return JobDefinitionResponse(job_def_id=job_def_seq_to_id(job_def_seq))

--- a/libs/python/ripple/ripple/automation/publishers.py
+++ b/libs/python/ripple/ripple/automation/publishers.py
@@ -116,7 +116,7 @@ class ResultPublisher:
                 'name': job_def.name,
                 'description': job_def.description,
                 'params_schema': job_def.parameter_spec.model_dump(),
-                'source': job_def.source
+                'source': job_def.source.model_dump() if job_def.source else None,
             }
             response = self.rest.post(f"{api_url}/jobs/definitions", definition, self.request.auth_token,
                 headers=self.request.telemetry_context


### PR DESCRIPTION
Gracefully handle republishing a package without bumping the version number (Updates link to point to the new job_def).
Fix json parsing error when publishing a job_def with an asset source.