### PR TITLE
[env/debug] Enabling:

### DIFF
--- a/api/app/debug_entrypoint.sh
+++ b/api/app/debug_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Run DB migration to ensure database is at latest revision
+poetry run alembic upgrade head
+
+
+poetry run uvicorn main:app --host 0.0.0.0 --port 5555

--- a/api/nginx/Dockerfile
+++ b/api/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.25.5-alpine
 
 LABEL name="mythica-web-front"
 LABEL maintainer="jacobrepp@gmail.com"
-LABEL verison="1.0.0"
+LABEL version="1.0.0"
 LABEL tier="web"
 LABEL description="NGINX front end configured for mythica services"
 
@@ -11,6 +11,7 @@ WORKDIR /
 ENV API_ENDPOINT=app:5555
 ENV DEX_ENDPOINT=dex:5556
 ENV EXTERNAL_IP=127.0.0.1
+ENV MYTHICA_ENVIRONMENT=local
 
 COPY conf/variables.template /etc/nginx/templates/10-variables.conf.template
 COPY conf/upstream.template /etc/nginx/templates/11-upstream.conf.template
@@ -20,4 +21,4 @@ COPY ./docker-entrypoint.sh /
 
 # override the base image, provide a different config for deployment environments
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["nginx", "-c", "/etc/nginx/nginx-local.conf"]
+CMD ["nginx"]

--- a/api/nginx/conf/nginx-debug.conf
+++ b/api/nginx/conf/nginx-debug.conf
@@ -1,0 +1,203 @@
+load_module modules/ngx_stream_js_module.so;
+load_module modules/ngx_http_js_module.so;
+
+daemon off;
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/conf.d/10-variables.conf;
+    include /etc/nginx/conf.d/11-upstream.conf;
+    include /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    js_import log_headers.js;
+
+    client_header_timeout  3m;
+    client_body_timeout    3m;
+    send_timeout           3m;
+
+    # Map the proxy schema
+    map $http_x_forwarded_proto $proxy_scheme {
+        default $scheme;
+        https https;
+    }
+
+        # Define log formats
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+
+
+
+    # Access log
+    access_log /var/log/nginx/access.log main;
+
+     # Redirect access logs to stdout
+    access_log /dev/stdout;
+
+    # Error log to file
+    error_log /var/log/nginx/error.log;
+
+     # Error logs to stdout for easy debugging
+    error_log /dev/stdout warn;
+
+    upstream minio {
+        least_conn;
+        server minio:9000;
+    }
+
+    upstream app {
+        least_conn;
+        server 172.17.0.1:5555;
+    }
+
+    upstream jungle3 {
+        least_conn;
+        server 172.17.0.1:5173;
+    }
+
+    upstream awfului {
+        least_conn;
+        server 172.17.0.1:5174;
+    }
+
+    server {
+        listen       80; # ipv4
+        listen  [::]:80; # ipv6
+        server_name  localhost;
+        proxy_set_header X-Real-IP $external_ip;
+        proxy_set_header Host $host;
+
+        proxy_set_header X-Forwarded-Proto $proxy_scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # Expose a simple health check endpoing
+        location /healthz {
+            access_log off;
+            default_type text/plain;
+            return 200 "healthy\n";
+        }
+
+        # Expose a status query endpoint
+        location /nginx_status {
+            stub_status on;
+            access_log off;
+            allow 127.0.0.1;
+            allow 172.16.0.0/12;
+            deny all;
+        }
+
+        location /log-headers {
+            js_header_filter log_headers.headers_json_log;
+            return 200;
+        }
+
+        location /awful/ {
+            proxy_pass http://awfului;
+
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_set_header Cross-Origin-Embedder-Policy "require-corp";
+            proxy_set_header Cross-Origin-Opener-Policy "same-origin";
+        }
+        
+        location / {
+            proxy_pass http://jungle3;
+
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /v1/readers/connect {
+            proxy_pass http://app;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+
+            proxy_connect_timeout 70;
+            proxy_send_timeout 90;
+            proxy_read_timeout 90;
+
+            proxy_buffer_size 4k;
+            proxy_buffers 4 32k;
+            proxy_busy_buffers_size 64k;
+            proxy_temp_file_write_size 64k;
+
+            client_max_body_size 100M;
+        }
+
+
+        location  /v1  {
+            proxy_pass http://app;
+
+            proxy_connect_timeout      70;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+            
+        }
+
+        location /images {
+            proxy_pass http://minio;
+
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 300;
+            # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            chunked_transfer_encoding off;
+        }
+
+        location  /docs  {
+            proxy_pass http://app;
+        }
+
+        location ~ ^/gcs-files_(.*) {
+            rewrite ^/gcs-files_(.*) /files/$1 break;
+            proxy_pass         http://minio;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+
+            # Set headers
+            add_header Cross-Origin-Embedder-Policy "require-corp";
+            add_header Cross-Origin-Opener-Policy "same-origin";
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+
+            # Remove specific headers from the response
+            proxy_hide_header x-goog-generation;
+            proxy_hide_header x-goog-metageneration;
+            proxy_hide_header x-goog-stored-content-encoding;
+            proxy_hide_header x-goog-stored-content-length;
+            proxy_hide_header x-goog-hash;
+            proxy_hide_header x-goog-storage-class;
+            proxy_hide_header x-guploader-uploadid;
+            
+            proxy_connect_timeout      70;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+        }        
+    }
+}

--- a/api/nginx/debug-entrypoint.sh
+++ b/api/nginx/debug-entrypoint.sh
@@ -1,0 +1,1 @@
+docker run -it --rm -e MYTHICA_ENVIRONMENT=debug -p 8080:80 --network storage mythica-web-front

--- a/sites/awful-ui/vite.config.ts
+++ b/sites/awful-ui/vite.config.ts
@@ -44,10 +44,11 @@ export default defineConfig({
       "Cross-Origin-Embedder-Policy": "require-corp",
       "Cross-Origin-Opener-Policy": "same-origin",
     },
+    host: '0.0.0.0',
     port: 5174,
     proxy: {
       '/mythica-api': {
-        target: 'http://localhost:15555/v1',
+        target: 'http://localhost:5555/v1',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/mythica-api/, ''),
       },

--- a/sites/jungle3/vite.config.ts
+++ b/sites/jungle3/vite.config.ts
@@ -5,6 +5,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  server: {port: 5173},
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  },
   plugins: [react(), tsconfigPaths(), runtimeEnv()],
 });


### PR DESCRIPTION
run jungle, awful, app from cmd line or VS Code, served by nginx container that proxies all that to localhost:8080

```
cd api/app && ./debug_entrypoint.sh && cd ..
cd sites/jungle3 && pnpm run dev && cd ..
cd sites/awful-ui && pnpm run dev && cd ..
cd api/nginx &&  ./debug_entrypoint.sh && cd ..
```