### PR TITLE
[gha] add codecov step to libs ci

### DIFF
--- a/.github/workflows/libs-python-ci.yaml
+++ b/.github/workflows/libs-python-ci.yaml
@@ -62,8 +62,19 @@ jobs:
           poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-      - id: pytester-cov
+      - name: Generate coverage
         working-directory: ${{ matrix.library }}
         run: |
-          poetry run pytest
+          poetry run pytest --timeout=10 --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
         shell: bash
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This change attempts to push python library code test coverage