### PR TITLE
[api/app] Fix alembic error setting up clean environment

### DIFF
--- a/api/app/alembic/versions/6fa8abcb5189_fixup_asset_version_json.py
+++ b/api/app/alembic/versions/6fa8abcb5189_fixup_asset_version_json.py
@@ -30,7 +30,13 @@ def upgrade() -> None:
     bind = op.get_bind()
     session = Session(bind)
 
-    asset_versions = session.exec(select(AssetVersion)).all()
+    asset_versions = session.exec(select(
+        AssetVersion.asset_seq,
+        AssetVersion.major,
+        AssetVersion.minor,
+        AssetVersion.patch,
+        AssetVersion.contents
+    )).all()
     contents_as_string = 0
     contents_with_string_lists = 0
     contents_list_converted = 0


### PR DESCRIPTION
This was caused by #659 

There is an older alembic version upgrade script that was querying the database in the middle of the upgrade. This was causing issues because the "AsssetVersion" type it is referencing in the script is the latest definition. This was causing it to try to query for a field that doesn't exist yet.

Working around by making it only query for fields it is trying to use. These fields happen to still be compatible with the latest version.

This fixes it to not hit the assert, but I am not sure if the body of the logic actually still works or if the update(AssetVersion) call lower down will hit the same issue.