### PR TITLE
[houdini] Fix old job_def breaking due to new parameter

### DIFF
--- a/automation/houdini/automation/generate_mesh.py
+++ b/automation/houdini/automation/generate_mesh.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from ripple.automation.publishers import ResultPublisher
 from ripple.models.params import FileParameter, ParameterSet
 from ripple.models.streaming import OutputFiles
+from typing import Optional
 
 tracer = trace.get_tracer(__name__)
 logging.basicConfig(
@@ -261,7 +262,7 @@ class ExportMeshRequest(ParameterSet):
     hda_file: FileParameter
     hda_definition_index: int
     format: str
-    record_profile: bool
+    record_profile: Optional[bool] = False
 
 
 class ExportMeshResponse(OutputFiles):


### PR DESCRIPTION
We currently don't have a mechanism to version automation scripts. So old job_defs running on the new automation script were failing due to missing the new parameter.

Mitigating for now by marking the new field as optional.