### PR TITLE
[api/app/tags]: Tags with priority 0 should not be shown. Fix permissions for sql_profiler_decorator.

### DIFF
--- a/api/app/db/connection.py
+++ b/api/app/db/connection.py
@@ -91,10 +91,12 @@ def sql_profiler_decorator(func, report_name="report.html"):
     def wrapper(*args, **kwargs):
         if not ripple_config().mythica_environment == "debug":
             return func(*args, **kwargs)
-
-        profiler = sqltap.start()
-        result = func(*args, **kwargs)
-        statistics = profiler.collect()
-        sqltap.report(statistics, report_name)
+        try:
+            profiler = sqltap.start()
+            result = func(*args, **kwargs)
+            statistics = profiler.collect()
+            sqltap.report(statistics, report_name)
+        except PermissionError:
+            result = func(*args, **kwargs)
         return result
     return wrapper

--- a/api/app/routes/tags/tags.py
+++ b/api/app/routes/tags/tags.py
@@ -84,7 +84,11 @@ async def list_all(limit: int = Query(1, le=100), offset: int = 0) -> list[TagRe
     """Get all tags"""
     with get_session() as session:
         rows: Sequence[Tag] = session.exec(
-            select(Tag).order_by(asc(Tag.page_priority), desc(Tag.created)).limit(limit).offset(offset)
+            select(Tag).where(
+                Tag.page_priority > 0
+            ).order_by(
+                asc(Tag.page_priority), desc(Tag.created)
+            ).limit(limit).offset(offset)
         ).all()
 
         response = [


### PR DESCRIPTION
If priority = 1 should appear before priority = 2, then the sorting should be ascending