### PR TITLE
[canary/telemetry]: 🧾 Add telemetry to the canary.

### DIFF
--- a/api/canary/Dockerfile
+++ b/api/canary/Dockerfile
@@ -4,7 +4,8 @@ LABEL name="mythica-job-canary"
 LABEL description="Automated canary test for the job pipeline"
 LABEL tier="automation"
 
-RUN pip install --upgrade pip requests
+RUN pip install --upgrade pip && \
+    pip install requests opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 
 WORKDIR /api/canary
 
@@ -14,6 +15,12 @@ COPY . .
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV OTEL_RESOURCE_ATTRIBUTES="service.name=canary"
+ENV MYTHICA_ENVIRONMENT=dev
+ENV MYTHICA_LOCATION=localhost
+ENV TELEMETRY_ENABLE=True
+ENV TELEMETRY_ENDPOINT=otel-sidecar:4317
+ENV TELEMETRY_INSECURE=True
+ENV K8S_CLUSTER_NAME=localhost
 
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1

--- a/api/canary/telemetry.py
+++ b/api/canary/telemetry.py
@@ -1,0 +1,124 @@
+# copy from libs/python/ripple/ripple/config.py
+import json
+import logging
+import os
+import traceback
+from typing import Optional
+
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import (
+    BatchLogRecordProcessor,
+    ConsoleLogExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.resources import OTELResourceDetector, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.trace import set_tracer_provider
+
+
+def get_telemetry_resource() -> Resource:
+    detected_resource = OTELResourceDetector().detect()
+    
+    resource = Resource.create(
+        {
+            "APP_VERSION": os.getenv("APP_VERSION", "local"),
+            "MYTHICA_LOCATION": os.getenv("MYTHICA_LOCATION", "local"),
+            ResourceAttributes.K8S_CLUSTER_NAME: os.getenv("K8S_CLUSTER_NAME", "local"),
+            ResourceAttributes.K8S_NAMESPACE_NAME: os.getenv(
+                "NAMESPACE", "dev"
+            ),
+            ResourceAttributes.SERVICE_NAMESPACE: os.getenv(
+                "NAMESPACE", "dev"
+            ),
+            ResourceAttributes.DEPLOYMENT_ENVIRONMENT: os.getenv("NAMESPACE", "local"),
+        }
+    )
+    # detected_resource overrides resource with vars from OTEL_RESOURCE_ATTRIBUTES
+    resource = resource.merge(detected_resource)
+
+    return resource
+
+
+def configure_telemetry(telemetry_endpoint: str, telemetry_insecure: bool, headers: Optional[list[tuple]] = None):
+
+    logger = logging.getLogger()
+    logger.info(
+        "Telemetry enabled. telemetry_endpoint: %s, telemetry_insecure: %s",
+        telemetry_endpoint,
+        telemetry_insecure,
+    )
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.handlers.clear()
+
+    #
+    # Metadata and access configuration
+    #
+    resource = get_telemetry_resource()
+
+    #
+    # OpenTelemetry Tracer configuration
+    #
+    tracer_provider = TracerProvider(resource=resource)
+    set_tracer_provider(tracer_provider)
+    span_exporter = OTLPSpanExporter(
+        endpoint=telemetry_endpoint,
+        insecure=telemetry_insecure,
+        headers=headers,
+    )
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    #
+    # OpenTelemetry Logging Exporter
+    #
+    logger_provider = LoggerProvider(resource=resource)
+    set_logger_provider(logger_provider)
+    exporter = OTLPLogExporter(
+        endpoint=telemetry_endpoint,
+        insecure=telemetry_insecure,
+        headers=headers,
+    )
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    if resource.attributes.get("MYTHICA_LOCATION") == "localhost":
+        logger_provider.add_log_record_processor(
+            SimpleLogRecordProcessor(ConsoleLogExporter())
+        )
+
+    otel_log_handler = LoggingHandler(level=logging.INFO)
+    logger.addHandler(otel_log_handler)
+
+    otel_log_handler.setFormatter(CustomJSONFormatter())
+
+
+class CustomJSONFormatter(logging.Formatter):
+    def format(self, record):
+        record_message = record.getMessage()
+
+        log_entry = {
+            "message": record_message,
+            "level": record.levelname,
+            "time": self.formatTime(record),
+        }
+        if record.exc_info:
+            exception_type, exception_value, _ = record.exc_info
+            log_entry.update(
+                {
+                    "exception_type": getattr(exception_type, "__name__", "Unknown"),
+                    "exception_value": str(exception_value),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+        log_entry.update(
+            {
+                k: v
+                for k, v in record.__dict__.items()
+                if k
+                not in ['msg', 'args', 'levelname', 'asctime', 'message', 'exc_info']
+            }
+        )
+        json_log_entry = json.dumps(log_entry)
+        return json_log_entry

--- a/api/helm/api/templates/deployment-canary.yaml
+++ b/api/helm/api/templates/deployment-canary.yaml
@@ -39,6 +39,14 @@ spec:
               value: "{{ .Values.location }}"
             - name: K8S_CLUSTER_NAME
               value: "{{ .Values.location }}"
+            - name: TELEMETRY_ENABLE
+              value: "{{ .Values.api.canary.telemetry_enable }}"
+            - name: TELEMETRY_ENDPOINT
+              value: {{ .Values.api.canary.telemetry_endpoint }}
+            - name: TELEMETRY_INSECURE
+              value: "{{ .Values.api.canary.telemetry_insecure }}"
+            - name: NAMESPACE
+              value: {{ .Values.namespace }}
 
             - name: MYTHICA_API_KEY
               valueFrom:

--- a/api/helm/api/values-staging.yaml
+++ b/api/helm/api/values-staging.yaml
@@ -70,5 +70,8 @@ api:
     replicas: 1
     maxUnavailable: 0
     maxSurge: 2
+    telemetry_enable: "true"
+    telemetry_endpoint: "http://otel-collector.default:4317"
+    telemetry_insecure: "true"
     nodeSelector: spot
     terminationGracePeriodSeconds: 15

--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -77,5 +77,8 @@ api:
     replicas: 0
     maxUnavailable: 0
     maxSurge: 0
+    telemetry_enable: "true"
+    telemetry_endpoint: "http://otel-collector.default:4317"
+    telemetry_insecure: "true"
     nodeSelector: spot
     terminationGracePeriodSeconds: 15


### PR DESCRIPTION
 Union traces across automation and api/app with telemetry context
 It captured three services🥳.
![Screenshot from 2025-02-14 15-11-42](https://github.com/user-attachments/assets/8bf921d4-161d-40b5-acba-1fda4ddc46d4)

