### PR TITLE
[ripple] Disable file chunk streaming

### DIFF
--- a/libs/python/ripple/ripple/automation/publishers.py
+++ b/libs/python/ripple/ripple/automation/publishers.py
@@ -111,8 +111,8 @@ class ResultPublisher:
                 return None
 
             try:
-                if self.request.results_subject:
-                    self._stream_file_chunks(file_path, key, index)
+                #if self.request.results_subject:
+                #    self._stream_file_chunks(file_path, key, index)
 
                 with open(file_path, 'rb') as file:
                     file_name = os.path.basename(file_path)


### PR DESCRIPTION
Going to disable this for now until we get the new websocket protocol ready.

Currently this is creating a lot of log spam. This code is going to be changed soon with the new protocol, so just disabling for now rather than trying to improve this code that will soon be changed.