### PR TITLE
[api/canary] Quick fix the obtaining TELEMETRY_INSECURE from env

### DIFF
--- a/api/canary/job_canary.py
+++ b/api/canary/job_canary.py
@@ -15,7 +15,7 @@ from telemetry import configure_telemetry
 if os.getenv("TELEMETRY_ENABLE", "False").lower() == "true":
     configure_telemetry(
         os.getenv("TELEMETRY_ENDPOINT", "localhost:4317"),
-        os.getenv("TELEMETRY_INSECURE", "False") == "True",
+        os.getenv("TELEMETRY_INSECURE", "False").lower() == "true",
     )
 else:
     logging.basicConfig(


### PR DESCRIPTION
I forgot to do the same for TELEMETRY_INSECURE var. 