### PR TITLE
[jungle3] babylon integration for assets

### DIFF
--- a/sites/jungle3/src/components/BabylonViewer/SceneControls.tsx
+++ b/sites/jungle3/src/components/BabylonViewer/SceneControls.tsx
@@ -12,9 +12,10 @@ import { useSceneStore, ParameterSlider } from "@store/sceneStore";
 
 type Props = {
   width?: number;
+  isAssetPage?: boolean;
 };
 
-const SceneControls: FC<Props> = ({ width }) => {
+const SceneControls: FC<Props> = ({ width, isAssetPage }) => {
   // Get state and actions from the store
   const {
     hdaSchemas,
@@ -148,25 +149,27 @@ const SceneControls: FC<Props> = ({ width }) => {
       </Box>
 
       {/* HDA Selection */}
-      <FormControl sx={{ mb: 3 }}>
-        <FormLabel sx={{ color: "#e0e0e0" }}>Select Generator</FormLabel>
-        <Select
-          value={selectedHdaIndex}
-          onChange={handleHdaChange}
-          variant="outlined"
-          color="neutral"
-          sx={{
-            bgcolor: "#333",
-            "& .MuiSelect-indicator": { color: "#e0e0e0" },
-          }}
-        >
-          {hdaSchemas.map((schema, index) => (
-            <Option key={index} value={index}>
-              {schema.name}
-            </Option>
-          ))}
-        </Select>
-      </FormControl>
+      {!isAssetPage && (
+        <FormControl sx={{ mb: 3 }}>
+          <FormLabel sx={{ color: "#e0e0e0" }}>Select Generator</FormLabel>
+          <Select
+            value={selectedHdaIndex}
+            onChange={handleHdaChange}
+            variant="outlined"
+            color="neutral"
+            sx={{
+              bgcolor: "#333",
+              "& .MuiSelect-indicator": { color: "#e0e0e0" },
+            }}
+          >
+            {hdaSchemas.map((schema, index) => (
+              <Option key={index} value={index}>
+                {schema.name}
+              </Option>
+            ))}
+          </Select>
+        </FormControl>
+      )}
 
       {/* Parameters Section Header */}
       <Box

--- a/sites/jungle3/src/components/PackageView/PackageViewInfoPanel.tsx
+++ b/sites/jungle3/src/components/PackageView/PackageViewInfoPanel.tsx
@@ -20,12 +20,18 @@ import {
 } from "lucide-react";
 import { DownloadButton } from "@components/common/DownloadButton";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useSceneStore } from "@store/sceneStore";
 
 export const PackageViewInfoPanel: React.FC<AssetVersionResponse> = (
   av: AssetVersionResponse,
 ) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { hdaSchemas } = useSceneStore();
+  const matchesHdaSchema = hdaSchemas.find(
+    (schema) => schema.name === av?.name,
+  );
+
   const convertCommitRefToLink = (ref: string) => {
     if (ref && ref.startsWith("git@github.com")) {
       const site_user_path = ref.split(":");
@@ -80,17 +86,19 @@ export const PackageViewInfoPanel: React.FC<AssetVersionResponse> = (
 
   return (
     <Stack gap="10px">
-      <Button
-        variant="outlined"
-        color="neutral"
-        sx={{ width: "fit-content", alignSelf: "end", pr: "10px" }}
-        endDecorator={<LucideChevronRight width="20px" height="20px" />}
-        onClick={() => {
-          navigate(`${location.pathname}/jobs`);
-        }}
-      >
-        Visit automations
-      </Button>
+      {matchesHdaSchema && (
+        <Button
+          variant="outlined"
+          color="neutral"
+          sx={{ width: "fit-content", alignSelf: "end", pr: "10px" }}
+          endDecorator={<LucideChevronRight width="20px" height="20px" />}
+          onClick={() => {
+            navigate(`${location.pathname}/jobs`);
+          }}
+        >
+          Visit automations
+        </Button>
+      )}
       <Card>
         <Stack>
           <Stack direction={"row"} alignItems={"center"} gap={"8px"}>

--- a/sites/jungle3/src/pages/BabylonScenePage.tsx
+++ b/sites/jungle3/src/pages/BabylonScenePage.tsx
@@ -17,7 +17,11 @@ import { useSceneStore } from "@store/sceneStore";
 import { SceneTalkConnection } from "../services/sceneTalkConnection";
 import { useWindowSize } from "@hooks/useWindowSize";
 
-const BabylonScenePage = () => {
+type Props = {
+  schemaName?: string;
+};
+
+const BabylonScenePage: React.FC<Props> = ({ schemaName }) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(true);
   const wsServiceRef = useRef<SceneTalkConnection | null>(null);
@@ -44,7 +48,9 @@ const BabylonScenePage = () => {
   } = useSceneStore();
 
   // Get current HDA schema
-  const currentSchema = hdaSchemas[selectedHdaIndex];
+  const currentSchema = schemaName
+    ? hdaSchemas.find((schema) => schema.name === schemaName)
+    : hdaSchemas[selectedHdaIndex];
 
   // Initialize WebSocket service
   useEffect(() => {
@@ -124,10 +130,14 @@ const BabylonScenePage = () => {
     setRequestInFlight(true);
 
     // Get the file path for the current HDA
-    const hdaFilePath = currentSchema.file_path;
+    const hdaFilePath = currentSchema?.file_path;
 
     // Send the cook request with all parameters for the current HDA
-    wsServiceRef.current.sendCookRequest(hdaFilePath, paramValues, format);
+    wsServiceRef.current.sendCookRequest(
+      hdaFilePath as string,
+      paramValues,
+      format,
+    );
   };
 
   // Watch for export format changes
@@ -160,7 +170,7 @@ const BabylonScenePage = () => {
       </Helmet>
 
       {currentWidth > 700 ? (
-        <SceneControls />
+        <SceneControls isAssetPage={!!schemaName} />
       ) : (
         <Button
           color="neutral"
@@ -181,7 +191,10 @@ const BabylonScenePage = () => {
             <ModalClose />
             <DialogTitle>Controls</DialogTitle>
             <DialogContent>
-              <SceneControls width={currentWidth - 40} />
+              <SceneControls
+                isAssetPage={!!schemaName}
+                width={currentWidth - 40}
+              />
             </DialogContent>
           </ModalDialog>
         </Modal>

--- a/sites/jungle3/src/pages/PackageJobs.tsx
+++ b/sites/jungle3/src/pages/PackageJobs.tsx
@@ -33,6 +33,8 @@ import {
   extractValidationErrors,
   translateError,
 } from "@services/backendCommon";
+import { useSceneStore } from "@store/sceneStore";
+import BabylonScenePage from "./BabylonScenePage";
 
 const TabStyle = { ":focus": { outline: "none" } };
 const TabPanelStyle = { padding: "12px 0 0" };
@@ -52,6 +54,11 @@ export const PackageJobs = () => {
   const [inputData, setInputData] = useState<dictionary>({});
   const [selectedHdaId, setSelectedHdaId] = React.useState<null | string>(null);
   const { addError, addWarning } = useStatusStore();
+  const { hdaSchemas } = useSceneStore();
+
+  const matchesHdaSchema = hdaSchemas.find(
+    (schema) => schema.name === assetData?.name,
+  );
 
   const hdaFiles = assetData?.contents?.files.filter((file) =>
     file.file_name.includes(".hda"),
@@ -173,9 +180,38 @@ export const PackageJobs = () => {
             Back to Package view
           </Button>
         </Stack>
-        <Typography level="h4" textAlign="start" mt="24px">
-          No automation definitions found for this package.
-        </Typography>
+        {matchesHdaSchema ? (
+          <Tabs
+            aria-label="tabs"
+            defaultValue={0}
+            sx={{ width: "100%", bgcolor: "transparent" }}
+          >
+            <TabList
+              disableUnderline
+              sx={{
+                p: 0.5,
+                gap: 0.5,
+                borderRadius: "8px",
+                bgcolor: "background.level1",
+                [`& .${tabClasses.root}[aria-selected="true"]`]: {
+                  boxShadow: "sm",
+                  bgcolor: "background.surface",
+                },
+              }}
+            >
+              <Tab sx={TabStyle} disableIndicator>
+                3D Live Preview
+              </Tab>
+            </TabList>
+            <TabPanel value={0}>
+              <BabylonScenePage schemaName={assetData?.name} />
+            </TabPanel>
+          </Tabs>
+        ) : (
+          <Typography level="h4" textAlign="start" mt="24px">
+            No automation definitions found for this package.
+          </Typography>
+        )}
       </Stack>
     );
   }
@@ -236,6 +272,11 @@ export const PackageJobs = () => {
           <Tab sx={TabStyle} disableIndicator>
             Run automation
           </Tab>
+          {matchesHdaSchema && (
+            <Tab sx={TabStyle} disableIndicator>
+              3D Live Preview
+            </Tab>
+          )}
           <Tab sx={TabStyle} disableIndicator>
             Automation history
           </Tab>
@@ -309,7 +350,13 @@ export const PackageJobs = () => {
           </Stack>
         </TabPanel>
 
-        <TabPanel value={1} sx={TabPanelStyle}>
+        {matchesHdaSchema && (
+          <TabPanel value={1}>
+            <BabylonScenePage schemaName={assetData?.name} />
+          </TabPanel>
+        )}
+
+        <TabPanel value={matchesHdaSchema ? 2 : 1} sx={TabPanelStyle}>
           {jobResultsHistory && jobResultsHistory.length > 0 ? (
             <Stack gap="12px">
               {jobResultsHistory

--- a/sites/jungle3/src/stores/sceneStore.ts
+++ b/sites/jungle3/src/stores/sceneStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 // Parameter Schema Types
 export interface ParameterSlider {
-  type: 'slider';
+  type: "slider";
   label: string;
   min: number;
   max: number;
@@ -11,7 +11,7 @@ export interface ParameterSlider {
 }
 
 export interface ParameterHidden {
-  type: 'hidden';
+  type: "hidden";
   default: any;
 }
 
@@ -46,7 +46,7 @@ interface SceneState {
   setSelectedHdaIndex: (index: number) => void;
 
   // Parameter values
-  paramValues: {[key: string]: any};
+  paramValues: { [key: string]: any };
   updateParam: (key: string, value: any) => void;
   resetParams: () => void;
 
@@ -95,134 +95,134 @@ interface SceneState {
 // Define the parameter schemas from the test client
 const parameterSchemas: HDASchema[] = [
   {
-    name: 'Crystal',
-    file_path: 'assets/mythica.crystal.1.0.hda',
-    material_name: 'crystal',
+    name: "Crystals",
+    file_path: "assets/mythica.crystal.1.0.hda",
+    material_name: "crystal",
     parameters: {
       length: {
-        type: 'slider',
-        label: 'Length',
+        type: "slider",
+        label: "Length",
         min: 0.5,
         max: 5,
         step: 0.1,
-        default: 2.5
+        default: 2.5,
       },
       radius: {
-        type: 'slider',
-        label: 'Radius',
+        type: "slider",
+        label: "Radius",
         min: 0.1,
         max: 2,
         step: 0.1,
-        default: 0.6
+        default: 0.6,
       },
       numsides: {
-        type: 'slider',
-        label: 'Sides',
+        type: "slider",
+        label: "Sides",
         min: 3,
         max: 12,
         step: 1,
-        default: 6
-      }
-    }
+        default: 6,
+      },
+    },
   },
   {
-    name: 'Rock Generator',
-    file_path: 'assets/Mythica.RockGenerator.1.0.hda',
-    material_name: 'rock',
+    name: "RockGenerator",
+    file_path: "assets/Mythica.RockGenerator.1.0.hda",
+    material_name: "rock",
     parameters: {
       seed: {
-        type: 'slider',
-        label: 'Randomize',
+        type: "slider",
+        label: "Randomize",
         min: 0,
         max: 100,
         step: 1,
         default: 0,
       },
       smoothing: {
-        type: 'slider',
-        label: 'Smoothing',
+        type: "slider",
+        label: "Smoothing",
         min: 0,
         max: 50,
         step: 1,
-        default: 25
+        default: 25,
       },
       flatten: {
-        type: 'slider',
-        label: 'Flatten',
+        type: "slider",
+        label: "Flatten",
         min: 0,
         max: 1,
         step: 0.1,
-        default: 0.3
+        default: 0.3,
       },
       npts: {
-        type: 'hidden',
-        default: 5
-      }
+        type: "hidden",
+        default: 5,
+      },
     },
   },
   {
-    name: 'Rockify',
-    file_path: 'assets/Mythica.Rockify.1.0.hda',
-    material_name: 'rockface',
+    name: "Rockify",
+    file_path: "assets/Mythica.Rockify.1.0.hda",
+    material_name: "rockface",
     parameters: {
       Stage: {
-        type: 'slider',
-        label: 'Stage',
+        type: "slider",
+        label: "Stage",
         min: 0,
         max: 3,
         step: 1,
         default: 1,
       },
       base_rangemax: {
-        type: 'slider',
-        label: 'Base Noise',
+        type: "slider",
+        label: "Base Noise",
         min: 0.0,
         max: 10.0,
         step: 0.5,
-        default: 6.5
+        default: 6.5,
       },
       mid_rangemax: {
-        type: 'slider',
-        label: 'Mid Noise',
+        type: "slider",
+        label: "Mid Noise",
         min: 0.0,
         max: 3,
         step: 0.25,
-        default: 0.25
+        default: 0.25,
       },
       top_rangemax: {
-        type: 'slider',
-        label: 'Top Noise',
+        type: "slider",
+        label: "Top Noise",
         min: 0.0,
         max: 5.0,
         step: 0.5,
-        default: 0.5
+        default: 0.5,
       },
       smoothingiterations: {
-        type: 'hidden',
-        default: 0
+        type: "hidden",
+        default: 0,
       },
       vertDensity: {
-        type: 'hidden',
-        default: 0.1
+        type: "hidden",
+        default: 0.1,
       },
       size: {
-        type: 'hidden',
-        default: 512
+        type: "hidden",
+        default: 512,
       },
       input0: {
-        type: 'hidden',
+        type: "hidden",
         default: {
           file_id: "file_xxx",
-          file_path: "assets/SM_Shape_04_a.usd"
-        }
+          file_path: "assets/SM_Shape_04_a.usd",
+        },
       },
-    }
-  }
+    },
+  },
 ];
 
 // Initialize default parameter values
 const initParamValues = (schemaIndex: number) => {
-  const params: {[key: string]: any} = {};
+  const params: { [key: string]: any } = {};
   const schema = parameterSchemas[schemaIndex];
 
   Object.entries(schema.parameters).forEach(([key, config]) => {
@@ -239,18 +239,20 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   setSelectedHdaIndex: (index) => {
     set({
       selectedHdaIndex: index,
-      paramValues: initParamValues(index)
+      paramValues: initParamValues(index),
     });
   },
 
   // Parameter values
   paramValues: initParamValues(2), // Initialize with Rockify parameters
-  updateParam: (key, value) => set((state) => ({
-    paramValues: { ...state.paramValues, [key]: value }
-  })),
-  resetParams: () => set((state) => ({
-    paramValues: initParamValues(state.selectedHdaIndex)
-  })),
+  updateParam: (key, value) =>
+    set((state) => ({
+      paramValues: { ...state.paramValues, [key]: value },
+    })),
+  resetParams: () =>
+    set((state) => ({
+      paramValues: initParamValues(state.selectedHdaIndex),
+    })),
 
   // WebSocket state
   wsStatus: "disconnected",
@@ -267,7 +269,8 @@ export const useSceneStore = create<SceneState>((set, get) => ({
 
   // Log state
   showLogWindow: false,
-  toggleLogWindow: () => set((state) => ({ showLogWindow: !state.showLogWindow })),
+  toggleLogWindow: () =>
+    set((state) => ({ showLogWindow: !state.showLogWindow })),
   setShowLogWindow: (value) => set({ showLogWindow: value }),
 
   // Generation metrics
@@ -276,9 +279,10 @@ export const useSceneStore = create<SceneState>((set, get) => ({
 
   // Status logs
   statusLog: [],
-  addStatusLog: (log) => set((state) => ({
-    statusLog: [...state.statusLog, log]
-  })),
+  addStatusLog: (log) =>
+    set((state) => ({
+      statusLog: [...state.statusLog, log],
+    })),
   clearStatusLog: () => set({ statusLog: [] }),
 
   // Export functions
@@ -304,7 +308,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       statusLog: [],
       exportFormat: null,
       requestInFlight: false,
-      pendingRequest: false
+      pendingRequest: false,
     });
-  }
+  },
 }));


### PR DESCRIPTION
This integration for assets is strictly based on our predefined hdaSchemas. (currently is for Rockify, Crystals, RockGenerator).

**NOTE**: the main correlation between an asset and our hdaSchemas is the asset name. this means the name is being checked and if it exists in the hdaSchemas, then it's considered hdaSchema exists for current asset.

- If hdaSchema exists, we display an additional tab in automations page called '3D Live Preview'. I wasn't sure about the name so we can change it if needed. 
- If hdaSchema exists, but no automation definition is found for current asset, we still display a single tab '3D Live Preview'
- On AssetView page, if hdaSchema does not exist, we don't show the 'Visit Automations' page. 
- On the integrated BabylonViewer the hda dropdown selector is hidden. 

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/1e107a28-474a-4ab8-b170-6c089eead960" />

---

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/e8d757db-d3d4-4709-8057-5b33c1921981" />

---

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/62782d61-004d-448a-9227-9d9d6806cb2c" />
