### PR TITLE
[jungle] Remove fast mesh update path to fix loading issues

### DIFF
--- a/sites/jungle3/src/components/BabylonViewer/SceneViewer.tsx
+++ b/sites/jungle3/src/components/BabylonViewer/SceneViewer.tsx
@@ -219,17 +219,6 @@ const SceneViewer = () => {
     vertexData.normals = normals;
     vertexData.uvs = uvs;
 
-    // Fast path to update existing mesh if vertex count matches
-    if (customMeshRef.current) {
-      const currentVertexCount = customMeshRef.current.getTotalVertices();
-      const newVertexCount = vertices.length / 3;
-
-      if (currentVertexCount === newVertexCount) {
-        vertexData.applyToMesh(customMeshRef.current);
-        return;
-      }
-    }
-
     // Create a new mesh and swap to it once it's ready
     const newMesh = new BABYLON.Mesh("customMesh_new", sceneRef.current);
 
@@ -240,7 +229,7 @@ const SceneViewer = () => {
       newMesh.material.wireframe = isWireframe;
     }
 
-    vertexData.applyToMesh(newMesh, true);
+    vertexData.applyToMesh(newMesh);
 
     // Add to shadow generator
     if (shadowGeneratorRef.current) {


### PR DESCRIPTION
When you create a mesh, you specify whether it should support the vertex data being update dynamically. Using this option seems to be causing it to fail to load the mesh data correctly.

I am unsure why as the same pattern was working in the original HTML version. However this was a minor optimization so going to just unwind it for now to hopefully fix some of the larger issue. (eg. when you first load into the page, the mesh fails to display)