### PR TITLE
[ripple/houdini] fix

### DIFF
--- a/automation/houdini/automation/run_hda.py
+++ b/automation/houdini/automation/run_hda.py
@@ -23,6 +23,7 @@ class NodeType(BaseModel):
     icon: str
     inputs: int
     outputs: int
+    python: str
     code: str
     category: str
     namespace: str
@@ -49,7 +50,8 @@ def hda(request: HdaRequest, responder: ResultPublisher) -> HdaResponse:
         for assetdef in hou.hda.definitionsInFile(hda.file_path):
             # Get the node type for the asset
             nodeType = mnet.get_node_type(assetdef.nodeType())
-
+            nodeType['python'] = nodeType['code']
+            
             # Generate litegraph class in the temp directory
             nodeType['code'] = mpt.transpiler(nodeType['code'])
             del(nodeType['defaults'])

--- a/automation/houdini/workers.py
+++ b/automation/houdini/workers.py
@@ -16,6 +16,9 @@ from automation.helloworld import hello_world_api, HelloWorldRequest, HelloWorld
 from ripple.automation.worker import Worker
 from ripple.config import configure_telemetry, ripple_config
 
+# Get environment from MYTHICA_ENVIRONMENT env var
+mythica_environment = os.environ.get("MYTHICA_ENVIRONMENT", "prod")
+debug = mythica_environment == "debug"
 
 worker = Worker()
 
@@ -38,7 +41,7 @@ automations = [
         "provider": job_defs,
         "inputModel": JobDefRequest,
         "outputModel": JobDefResponse,
-        "hidden": True
+        "hidden": not debug
     },
     {
         "path": '/mythica/generate_mesh',

--- a/libs/python/ripple/ripple/models/houClasses.py
+++ b/libs/python/ripple/ripple/models/houClasses.py
@@ -255,7 +255,7 @@ class RampParmTemplate(ParmTemplate):
         points = []
         for match in pattern.finditer(ramp_str):
             pos = float(match.group(2).strip())
-            interp_str = match.group(4).strip().lower()
+            interp_str = match.group(4).strip().lower().replace("-","").replace(" ","")
             interp = rampBasis.Constant
             for b in rampBasis:
                 # b.value is the string value in the enum, e.g. "MonotoneCubic"


### PR DESCRIPTION
- catmull-rom and b-spline need the '-' trimmed
- defensively also trimming ' '
- adding python output to hda automation for debugging
- exposing job_def for debugging