### PR TITLE
[jungle3/houdini-ui] Sliders on mobile for Int & Float params

### DIFF
--- a/sites/libs/houdini-ui/src/components/FloatParm.tsx
+++ b/sites/libs/houdini-ui/src/components/FloatParm.tsx
@@ -1,78 +1,89 @@
 import React, { ChangeEvent, useState } from 'react';
-import hou,{ dictionary } from '../types/Houdini';
+import hou, { dictionary } from '../types/Houdini';
+import { useWindowSize } from '../util/useWindowSize';
 
 export interface FloatParmProps {
-    template: hou.FloatParmTemplate;
-    data: dictionary;
-    onChange: (formData: dictionary) => void; // Callback for value changes
+  template: hou.FloatParmTemplate;
+  data: dictionary;
+  onChange: (formData: dictionary) => void; // Callback for value changes
+  useSlidersOnMobile?: boolean;
 }
 
-export const FloatParm: React.FC<FloatParmProps> = ({template, data, onChange}) => {
-    
-    const [values, setValues] = useState<number[]>(() =>
-        data[template.name] ||
-        template.default_value.length === template.num_components
-            ? template.default_value
-            : Array<number>(template.num_components).fill(0)
-    );
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const parsedValue = parseFloat(e.target.value) || 0;
-        const index =  e.target.getAttribute('parm-index') as unknown as number;
+export const FloatParm: React.FC<FloatParmProps> = ({
+  template,
+  data,
+  onChange,
+  useSlidersOnMobile,
+}) => {
+  const [values, setValues] = useState<number[]>(() =>
+    data[template.name] ||
+    template.default_value.length === template.num_components
+      ? template.default_value
+      : Array<number>(template.num_components).fill(0)
+  );
+  const { currentWidth } = useWindowSize();
+  const isMobileSize = currentWidth <= 700 && useSlidersOnMobile;
 
-        // Validate the value
-        let validatedValue = parsedValue;
-        if (template.min !== undefined) {
-            if (template.min_is_strict && validatedValue <= template.min) {
-                validatedValue = template.min + 1e-6; // Adjust slightly above min if strict
-            } else if (!template.min_is_strict && validatedValue < template.min) {
-                validatedValue = template.min;
-            }
-        }
-        if (template.max !== undefined) {
-            if (template.max_is_strict && validatedValue >= template.max) {
-                validatedValue = template.max - 1e-6; // Adjust slightly below max if strict
-            } else if (!template.max_is_strict && validatedValue > template.max) {
-                validatedValue = template.max;
-            }
-        }
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const parsedValue = parseFloat(e.target.value) || 0;
+    const index = e.target.getAttribute('parm-index') as unknown as number;
 
-        // Update the state and notify parent
-        setValues((prev)=>{
-            prev[index] = validatedValue;
-            return prev;
-        });
+    // Validate the value
+    let validatedValue = parsedValue;
+    if (template.min !== undefined) {
+      if (template.min_is_strict && validatedValue <= template.min) {
+        validatedValue = template.min + 1e-6; // Adjust slightly above min if strict
+      } else if (!template.min_is_strict && validatedValue < template.min) {
+        validatedValue = template.min;
+      }
+    }
+    if (template.max !== undefined) {
+      if (template.max_is_strict && validatedValue >= template.max) {
+        validatedValue = template.max - 1e-6; // Adjust slightly below max if strict
+      } else if (!template.max_is_strict && validatedValue > template.max) {
+        validatedValue = template.max;
+      }
+    }
 
+    // Update the state and notify parent
+    setValues((prev) => {
+      prev[index] = validatedValue;
+      return prev;
+    });
 
-        //and notify listeners
-        const updatedValues = [...values];
-        updatedValues[index] = validatedValue;
-        const ret:{[key:string]: number[]} = {}
-        ret[template.name] = updatedValues
-        onChange?.(ret); // Notify parent about the change
-    };
+    //and notify listeners
+    const updatedValues = [...values];
+    updatedValues[index] = validatedValue;
+    const ret: { [key: string]: number[] } = {};
+    ret[template.name] = updatedValues;
+    onChange?.(ret); // Notify parent about the change
+  };
 
-    return (
-        <div className="float-parm" title={template.help}>
-            <label>{template.label}</label>
-            <div className="fields">
-                {values.map((value, index) => (
-                    <div key={template.name + index} className="field">
-                        <input
-                            type="number"
-                            value={value || 0}
-                            step="any"
-                            parm-index={index}
-                            onChange={handleChange}
-                            min={template.min}
-                            max={template.max}
-                            
-                            
-                        />
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
+  return (
+    <div className="float-parm" title={template.help}>
+      <label>{template.label}</label>
+      <div className="fields">
+        {values.map((value, index) => (
+          <div
+            key={template.name + index}
+            className={`field ${isMobileSize ? 'slider-field' : ''}`}
+          >
+            <input
+              type={isMobileSize ? 'range' : 'number'}
+              value={value || 0}
+              step="any"
+              parm-index={index}
+              onChange={handleChange}
+              min={template.min}
+              max={template.max}
+              className={isMobileSize ? 'input-slider' : ''}
+            />
+            {isMobileSize ? <span>{value?.toFixed(2)}</span> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default FloatParm;

--- a/sites/libs/houdini-ui/src/components/IntParm.tsx
+++ b/sites/libs/houdini-ui/src/components/IntParm.tsx
@@ -1,79 +1,92 @@
 import React, { ChangeEvent, useState } from 'react';
-import hou,{ dictionary } from '../types/Houdini';
-
+import hou, { dictionary } from '../types/Houdini';
+import { useWindowSize } from '../util/useWindowSize';
 
 export interface IntParmProps {
-    template: hou.IntParmTemplate;
-    data: dictionary;
-    onChange: (formData: dictionary) => void; // Callback for value changes
+  template: hou.IntParmTemplate;
+  data: dictionary;
+  onChange: (formData: dictionary) => void; // Callback for value changes
+  useSlidersOnMobile?: boolean;
 }
 
-export const IntParm: React.FC<IntParmProps> = ({template, data, onChange}) => {
-    const getDefaultValues = () => {
-        return data[template.name] ||
-            template.default_value.length === template.num_components
-            ? template.default_value
-            : Array<number>(template.num_components).fill(0);
+export const IntParm: React.FC<IntParmProps> = ({
+  template,
+  data,
+  onChange,
+  useSlidersOnMobile,
+}) => {
+  const getDefaultValues = () => {
+    return data[template.name] ||
+      template.default_value.length === template.num_components
+      ? template.default_value
+      : Array<number>(template.num_components).fill(0);
+  };
+
+  const { currentWidth } = useWindowSize();
+  const isMobileSize = currentWidth <= 700 && useSlidersOnMobile;
+
+  const [values, setValues] = useState<number[]>(getDefaultValues());
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const parsedValue = parseFloat(e.target.value) || 0;
+    const index = e.target.getAttribute('parm-index') as unknown as number;
+
+    // Validate the value
+    let validatedValue = parsedValue;
+    if (template.min !== undefined) {
+      if (template.min_is_strict && validatedValue <= template.min) {
+        validatedValue = template.min + 1; // Adjust slightly above min if strict
+      } else if (!template.min_is_strict && validatedValue < template.min) {
+        validatedValue = template.min;
+      }
+    }
+    if (template.max !== undefined) {
+      if (template.max_is_strict && validatedValue >= template.max) {
+        validatedValue = template.max - 1; // Adjust slightly below max if strict
+      } else if (!template.max_is_strict && validatedValue > template.max) {
+        validatedValue = template.max;
+      }
     }
 
-    const [values, setValues] = useState<number[]>(getDefaultValues());
+    // Update the state and notify parent
+    setValues((prev) => {
+      prev[index] = validatedValue;
+      return prev;
+    });
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const parsedValue = parseFloat(e.target.value) || 0;
-        const index =  e.target.getAttribute('parm-index') as unknown as number;
+    //and notify listeners
+    const updatedValues = [...values];
+    updatedValues[index] = validatedValue;
+    const ret: { [key: string]: number[] } = {};
+    ret[template.name] = updatedValues;
+    onChange?.(ret); // Notify parent about the change
+  };
 
-        // Validate the value
-        let validatedValue = parsedValue;
-        if (template.min !== undefined) {
-            if (template.min_is_strict && validatedValue <= template.min) {
-                validatedValue = template.min + 1; // Adjust slightly above min if strict
-            } else if (!template.min_is_strict && validatedValue < template.min) {
-                validatedValue = template.min;
-            }
-        }
-        if (template.max !== undefined) {
-            if (template.max_is_strict && validatedValue >= template.max) {
-                validatedValue = template.max - 1; // Adjust slightly below max if strict
-            } else if (!template.max_is_strict && validatedValue > template.max) {
-                validatedValue = template.max;
-            }
-        }
-
-        // Update the state and notify parent
-        setValues((prev)=>{
-            prev[index] = validatedValue;
-            return prev;
-        });
-
-        //and notify listeners
-        const updatedValues = [...values];
-        updatedValues[index] = validatedValue;
-        const ret:{[key:string]: number[]} = {}
-        ret[template.name] = updatedValues
-        onChange?.(ret); // Notify parent about the change
-    };
-
-    return (
-        <div className="int-parm" title={template.help}>
-            <label>{template.label}</label>
-            <div className="fields">
-                {values.map((value, index) => (
-                    <div key={template.name + index} className="field">
-                        <input
-                            type="number"
-                            value={value}
-                            step="1"
-                            parm-index={index}
-                            onChange={handleChange}
-                            min={template.min}
-                            max={template.max}
-                            
-                        />
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
+  return (
+    <div className="int-parm" title={template.help}>
+      <label>{template.label}</label>
+      <div className="fields">
+        {values.map((value, index) => (
+          <div
+            key={template.name + index}
+            className={`field ${isMobileSize ? 'slider-field' : ''}`}
+          >
+            <input
+              type={isMobileSize ? 'range' : 'number'}
+              value={value}
+              step="1"
+              parm-index={index}
+              onChange={handleChange}
+              min={template.min}
+              max={template.max}
+              className={isMobileSize ? 'input-slider' : ''}
+            />
+            {isMobileSize ? <span>{value}</span> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default IntParm;

--- a/sites/libs/houdini-ui/src/components/ParmFactory.tsx
+++ b/sites/libs/houdini-ui/src/components/ParmFactory.tsx
@@ -17,9 +17,10 @@ export interface ParmFactoryProps {
     parmTemplate: hou.ParmTemplate;
     data: dictionary;
     onChange: (formData: dictionary) => void; // Callback for value changes
+    useSlidersOnMobile?: boolean;
 }
 
-export const ParmFactory:React.FC<ParmFactoryProps> = ({parmTemplate, data, onChange}) => {
+export const ParmFactory:React.FC<ParmFactoryProps> = ({parmTemplate, data, onChange, useSlidersOnMobile}) => {
     switch (parmTemplate.param_type) {
         case hou.parmTemplateType.Folder:
             return <FolderParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.FolderParmTemplate} />;
@@ -28,9 +29,9 @@ export const ParmFactory:React.FC<ParmFactoryProps> = ({parmTemplate, data, onCh
         case hou.parmTemplateType.String:
             return <StringParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.StringParmTemplate} />;        
         case hou.parmTemplateType.Float:
-            return <FloatParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.FloatParmTemplate} />;        
+            return <FloatParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.FloatParmTemplate} useSlidersOnMobile={useSlidersOnMobile} />;        
         case hou.parmTemplateType.Int:
-            return <IntParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.IntParmTemplate} />;        
+            return <IntParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.IntParmTemplate} useSlidersOnMobile={useSlidersOnMobile} />;        
         case hou.parmTemplateType.Toggle:
             return <ToggleParm key={parmTemplate.id} data={data} onChange={onChange} template={parmTemplate as hou.ToggleParmTemplate} />;        
         case hou.parmTemplateType.Separator:

--- a/sites/libs/houdini-ui/src/components/ParmGroup.tsx
+++ b/sites/libs/houdini-ui/src/components/ParmGroup.tsx
@@ -1,23 +1,34 @@
 import React from 'react';
-import hou,{ dictionary } from '../types/Houdini';
+import hou, { dictionary } from '../types/Houdini';
 import { ParmFactory } from './ParmFactory';
 
 export interface ParmGroupProps {
-    group: hou.ParmTemplateGroup;
-    data: dictionary; 
-    onChange: (formData: dictionary) => void; // Callback for value changes
+  group: hou.ParmTemplateGroup;
+  data: dictionary;
+  onChange: (formData: dictionary) => void; // Callback for value changes
+  useSlidersOnMobile?: boolean;
 }
 
-export const ParmGroup: React.FC<ParmGroupProps> = ({ group, data, onChange }) => {
-
-    return (
-        <div className="parm-group nodrag">
-            {/* Render each ParmTemplate in the group */}
-            {group.parm_templates.map((template) => (
-                <ParmFactory key={template.id.toString()} data={data} parmTemplate={template} onChange={onChange} />
-            ))}
-        </div>
-    );
+export const ParmGroup: React.FC<ParmGroupProps> = ({
+  group,
+  data,
+  onChange,
+  useSlidersOnMobile = true,
+}) => {
+  return (
+    <div className="parm-group nodrag">
+      {/* Render each ParmTemplate in the group */}
+      {group.parm_templates.map((template) => (
+        <ParmFactory
+          key={template.id.toString()}
+          data={data}
+          parmTemplate={template}
+          onChange={onChange}
+          useSlidersOnMobile={useSlidersOnMobile}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default ParmGroup;

--- a/sites/libs/houdini-ui/src/houdini.css
+++ b/sites/libs/houdini-ui/src/houdini.css
@@ -206,3 +206,13 @@
   .folder-content {
     padding: 5px;
   }
+
+  .slider-field {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  
+  .input-slider {
+    accent-color: #367c64;
+  }

--- a/sites/libs/houdini-ui/src/util/useWindowSize.ts
+++ b/sites/libs/houdini-ui/src/util/useWindowSize.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export const useWindowSize = () => {
+  const [currentWidth, setCurrentWidth] = React.useState(window.innerWidth);
+  const [currentHeight, setCurrentHeight] = React.useState(window.innerHeight);
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      setCurrentWidth(window.innerWidth);
+      setCurrentHeight(window.innerHeight);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return {
+    currentWidth,
+    currentHeight,
+  };
+};


### PR DESCRIPTION
- added responsive threshold for switching Int & Float params to use sliders on mobile
- `<ParmGroup/>` has a new prop called `useSlidersOnMobile` which can be set to false to disable this behaviour

MOBILE <=700px screen width
<img width="652" alt="image" src="https://github.com/user-attachments/assets/19ab153e-0c13-4e16-8e5b-5dac32d41c8b" />

---

DESKTOP > 700px screen width (nothing changed for desktop)
<img width="751" alt="image" src="https://github.com/user-attachments/assets/69a299c1-5feb-47a8-84ee-a1aa96e24738" />
