### PR TITLE
[infra/tasks] postgresql

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -137,7 +137,7 @@ IMAGE_SETS = {
 
 LOCAL_MOUNT_POINTS = {
     'objstore': 'testing/mnt/objstore',
-    'pgdata': 'testing/mnt/pgdata',
+    'pgdata': 'testing/mnt/pgdata/data',
     'static': 'testing/mnt/static',
     'nats': 'testing/mnt/nats',
     'tailscale': 'testing/mnt/tailscale',

--- a/testing/storage/docker-compose.yaml
+++ b/testing/storage/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/
+      - pgdata:/var/lib/postgresql/data/
     healthcheck:
       test: pg_isready -U test
       interval: 5s


### PR DESCRIPTION
- make sure postgresql data survives restart by bind-mounting to .../postgresql/data/ instead of just .../postgresql/