### PR TITLE
[automation/houdini] fix

### DIFF
--- a/api/app/routes/jobs/jobs.py
+++ b/api/app/routes/jobs/jobs.py
@@ -334,6 +334,8 @@ async def create(
     if job_def is None:
         raise HTTPException(HTTPStatus.NOT_FOUND, detail="job_def_id not found")
 
+    # IMPORTANT: validation is done against params (not params_v2). Both Specs generate the
+    # same paramSet outputs so this is safe.
     parameter_spec = ParameterSpec(**job_def.params_schema)
     repair_parameters(parameter_spec, req_data.params)
     # validate parameters, report back the parameter error that caused the problem

--- a/automation/houdini/automation/generate_mesh.py
+++ b/automation/houdini/automation/generate_mesh.py
@@ -19,12 +19,13 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 log = logging.getLogger(__name__)
 
-rampkeys = {"interp", "x", "y"}
+rampkeysVal = {"interp", "pos", "value"}
+rampkeysCol = {"interp", "pos", "c"}
 
 
 def is_ramp_param(param):
     if isinstance(param, list) and all(isinstance(p, dict) for p in param):
-        if all(rampkeys.issubset(p.keys()) for p in param):
+        if all(rampkeysVal.issubset(p.keys()) for p in param) or all(rampkeysCol.issubset(p.keys()) for p in param):
             return True
     return False
 
@@ -42,11 +43,11 @@ def apply_single_param(asset, key, value):
         for point in value:
             try:
                 basis.append(RampBasis[point["interp"]].value)
-                keys.append(float(point["x"]))
-                if isinstance(point["y"], (float, int)):
-                    values.append(float(point["y"]))
-                else:
-                    values.append(hou.Vector3(point["y"]))
+                keys.append(float(point["pos"]))
+                if point["value"]:
+                    values.append(float(point["value"]))
+                elif point["c"]:
+                    values.append(hou.Vector3(float(point["c"])))
             except KeyError as e:
                 raise ValueError(f"Invalid key in ramp parameter: {e}") from e
             except Exception as e:

--- a/libs/python/ripple/ripple/models/houClasses.py
+++ b/libs/python/ripple/ripple/models/houClasses.py
@@ -49,6 +49,8 @@ class ParmTemplate:
     tags: dict[str, str] = {}
     default_expression: list[str] = []
     default_expression_language: list[scriptLanguage] = []
+    is_hidden: bool = False
+    is_label_hidden: bool = False
 
     def __init__(self, name: str, label: str = "", num_components: Optional[int] = None, **kwargs):
         self.name = name
@@ -117,6 +119,9 @@ class IntParmTemplate(ParmTemplate):
         return IntParmTemplateSpec(**self.__dict__)
     
     def getParameterSpec(self) -> list[IntParameterSpec]:
+        if self.is_hidden:
+            return []
+        
         default_value = self.default_value
         if isinstance(default_value, list) and self.num_components == 1:
             default_value = default_value[0]  # Convert list to scalar if num_components == 1
@@ -130,6 +135,9 @@ class FloatParmTemplate(ParmTemplate):
         return FloatParmTemplateSpec(**self.__dict__)
 
     def getParameterSpec(self) -> list[FloatParameterSpec]:
+        if self.is_hidden:
+            return []
+                
         default_value = self.default_value
         if isinstance(default_value, list) and self.num_components == 1:
             default_value = default_value[0]  # Convert list to scalar if num_components == 1
@@ -146,6 +154,9 @@ class StringParmTemplate(ParmTemplate):
         return StringParmTemplateSpec(**self.__dict__)
 
     def getParameterSpec(self) -> list[StringParameterSpec]:
+        if self.is_hidden:
+            return []
+        
         if self.menu_items and len(self.menu_items) > 0:
             value = {
                 "menu_items": self.menu_items,
@@ -169,8 +180,11 @@ class ToggleParmTemplate(ParmTemplate):
         return ToggleParmTemplateSpec(**self.__dict__)
 
     def getParameterSpec(self) -> list[BoolParameterSpec]:
+        if self.is_hidden:
+            return []
+        
         return [BoolParameterSpec(default=self.default_value, **self.__dict__)]
-
+        
 class MenuParmTemplate(ParmTemplate):
     type: parmTemplateType = parmTemplateType.Menu
     menu_items: list[str] = []
@@ -182,6 +196,9 @@ class MenuParmTemplate(ParmTemplate):
         return MenuParmTemplateSpec(**self.__dict__)
    
     def getParameterSpec(self) -> list[EnumParameterSpec]:
+        if self.is_hidden:
+            return []
+        
         value = {
             "menu_items": self.menu_items,
             "menu_labels": self.menu_labels,
@@ -224,6 +241,9 @@ class RampParmTemplate(ParmTemplate):
         return ret
 
     def getParameterSpec(self) -> list[RampParameterSpec]:
+        if self.is_hidden:
+            return []
+        
         default = self.default_points
 
         return [RampParameterSpec(default=default, **self.__dict__)]
@@ -312,6 +332,9 @@ class FolderParmTemplate(ParmTemplate):
         )
 
     def getParameterSpec(self) -> list[ParameterSpecType]:
+        if self.is_hidden:
+            return None
+        
         parameterSpecs: list[ParameterSpecType] = []
 
         for pt in self.parm_templates:

--- a/libs/python/ripple/ripple/runtime/params.py
+++ b/libs/python/ripple/ripple/runtime/params.py
@@ -4,9 +4,9 @@ from http import HTTPStatus
 import requests
 
 from ripple.models.params import (BoolParameterSpec, EnumParameterSpec, FileParameter, FileParameterSpec,
-                                  FloatParameterSpec, IntParameterSpec, ParameterSet, ParameterSpec, ParameterSpecModel,
+                                  FloatParameterSpec, IntParameterSpec, ParameterSet, ParameterSpec, ParameterSpecModel, RampParameterSpec,
                                   StringParameterSpec)
-
+from ripple.models.houTypes import (rampParmType, rampBasis)
 class ParamError(ValueError):
     def __init__(self, label, message):
         super().__init__(f"`{label}`: {message}")
@@ -54,8 +54,40 @@ def validate_param(paramSpec: ParameterSpecModel, param, expectedType) -> None:
     """Validate the parameter against the spec and expected type"""
     if not expectedType:
         raise ParamError(paramSpec.label, f"invalid type validation")
+    
+    if isinstance(paramSpec, RampParameterSpec):
+        #Check that param is a list of expectedType
+        if not isinstance(param, list):
+            raise ParamError(paramSpec.label, f"ramp params must be list of dict, got {type(param).__name__}")
+        for item in param:
+            rampType = paramSpec.ramp_parm_type
+            if rampType == rampParmType.Color:
+                vals = 'c'
+            else:
+                vals = 'value'
 
-    if isinstance(param, (list, tuple, set, frozenset)):
+            if not isinstance(item, expectedType):
+                raise ParamError(paramSpec.label, f"ramp point must be of type dict, got {type(item).__name__}")
+            if 'pos' not in item or vals not in item or 'interp' not in item:
+                raise ParamError(paramSpec.label, f"ramp point must contain 'pos' and 'value|c' and 'interp' keys")
+            if not isinstance(item['pos'],float):
+                raise ParamError(paramSpec.label, f"ramp point 'pos' must be of type float")
+            if rampType == rampParmType.Color:
+                if not isinstance(item[vals],list):
+                    raise ParamError(paramSpec.label, f"ramp point color 'c' must be of type list")
+                if (len(item[vals]) != 3):
+                    raise ParamError(paramSpec.label, f"ramp point color 'c' must be of length 3")
+                for c in item[vals]:
+                    if not isinstance(c,float):
+                        raise ParamError(paramSpec.label, f"ramp point color 'c' must be of type list of floats")
+            else:
+                if not isinstance(item[vals],float):
+                    raise ParamError(paramSpec.label, f"ramp point 'value' must be of type float")
+            #check that interp is a valid value from rampBasis
+            if item['interp'] not in [basis.name for basis in rampBasis]:
+                raise ParamError(paramSpec.label, f"ramp point 'interp' must be a valid value from hou.rampBasis")
+
+    elif isinstance(param, (list, tuple, set, frozenset)):
         if len(param) != len(paramSpec.default):
             raise ParamError(paramSpec.label, f"length mismatch {len(param)} != expected: {len(paramSpec.default)}")
         for item in param:
@@ -94,6 +126,8 @@ def validate_params(paramSpecs: ParameterSpec, paramSet: ParameterSet) -> None:
             use_type = bool
         elif isinstance(paramSpec, FileParameterSpec):
             use_type = FileParameter
+        elif isinstance(paramSpec, RampParameterSpec):
+            use_type = dict
         validate_param(paramSpec, param, use_type)
 
         # Validate enum

--- a/libs/python/ripple/tests/test_params.py
+++ b/libs/python/ripple/tests/test_params.py
@@ -3,12 +3,14 @@ import pytest
 import tempfile
 
 from ripple.compile.rpsc import compile_interface
+from ripple.models.houTypes import rampParmType, rampBasis
 from ripple.models.params import (
     ParameterSpec,
     ParameterSet,
     IntParameterSpec,
     FloatParameterSpec,
-    ParameterSpecModel, StringParameterSpec,
+    ParameterSpecModel,
+    RampParameterSpec, StringParameterSpec,
     BoolParameterSpec,
     EnumValueSpec,
     EnumParameterSpec,
@@ -384,7 +386,15 @@ def test_param_validation_all_types():
         'test_str': StringParameterSpec(label='test_str', default=''),
         'test_bool': BoolParameterSpec(label='test_bool', default=True),
         'test_enum': EnumParameterSpec(label='test_enum', default='a', values=[EnumValueSpec(name='a', label='A')]),
-        'test_file': FileParameterSpec(label='test_file', default='')
+        'test_file': FileParameterSpec(label='test_file', default=''),
+        'test_ramp_float': RampParameterSpec(
+            label='test_ramp_value', 
+            ramp_parm_type=rampParmType.Float,
+            default=[{'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear}]),
+        'test_ramp_color': RampParameterSpec(
+            label='test_ramp_color', 
+            ramp_parm_type=rampParmType.Color,
+            default=[{'pos': 0.0, 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}]),
     })
     set = ParameterSet(
         test_int=5,
@@ -392,7 +402,9 @@ def test_param_validation_all_types():
         test_str='test',
         test_bool=False,
         test_enum="a",
-        test_file=FileParameter(file_id='file_qfJSVuWRJvq5PmueFPxSjXsEcST')
+        test_file=FileParameter(file_id='file_qfJSVuWRJvq5PmueFPxSjXsEcST'),
+        test_ramp_float=[{'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear}, {'pos': 1.0, 'value': 1.0, 'interp': rampBasis.Linear}],
+        test_ramp_color=[{'pos': 0.0, 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}, {'pos': 1.0, 'c': [0.0, 0.0, 0.0], 'interp': rampBasis.Linear}],
     )
     validate_params(spec, set)
 
@@ -416,6 +428,86 @@ def test_param_validation_type_mismatch():
     with pytest.raises(ParamError) as exc_info:
         validate_params(spec, set_bad)
     assert_validation(exc_info.value, "did not match expected type")
+
+def test_param_validation_ramp():
+    spec = ParameterSpec(params={
+        'test_ramp': RampParameterSpec(
+            label='test', 
+            ramp_parm_type=rampParmType.Float, 
+            default=[{'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear}])})
+    set_bad_outer = ParameterSet(test_ramp={'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear})
+    set_bad_inner = ParameterSet(test_ramp=[0.0, 1.0])
+    set_bad_miss_pos = ParameterSet(test_ramp=[{'value': 0.0, 'interp': rampBasis.Linear}, {'pos': 1.0, 'value': 1.0, 'interp': rampBasis.Linear}])
+    set_bad_miss_value = ParameterSet(test_ramp=[{'pos': 0.0, 'interp': rampBasis.Linear}, {'pos': 1.0, 'value': 1.0, 'interp': rampBasis.Linear}])
+    set_bad_miss_interp = ParameterSet(test_ramp=[{'pos': 0.0, 'value': 0.0}, {'pos': 1.0, 'value': 1.0, 'interp': rampBasis.Linear}])
+    
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_outer)
+    assert_validation(exc_info.value, "ramp params must be list of dict")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_inner)
+    assert_validation(exc_info.value, "ramp point must be of type dict")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_miss_pos)
+    assert_validation(exc_info.value, "ramp point must contain 'pos' and 'value|c' and 'interp' keys")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_miss_value)
+    assert_validation(exc_info.value, "ramp point must contain 'pos' and 'value|c' and 'interp' keys")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_miss_interp)
+    assert_validation(exc_info.value, "ramp point must contain 'pos' and 'value|c' and 'interp' keys")
+
+def test_param_validation_ramp_float():
+    # Ramp float test
+    spec = ParameterSpec(params={
+        'test_ramp': RampParameterSpec(
+            label='test', 
+            ramp_parm_type=rampParmType.Float, 
+            default=[{'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear}])})
+    set_good = ParameterSet(test_ramp=[{'pos': 0.0, 'value': 0.0, 'interp': rampBasis.Linear}, {'pos': 1.0, 'value': 1.0, 'interp': rampBasis.Linear}])
+    set_bad_pos = ParameterSet(test_ramp=[{'pos': 'd', 'value': 0.0, 'interp': rampBasis.Linear}, {'pos': 'd', 'value': 0.0, 'interp': rampBasis.Linear}])
+    set_bad_value = ParameterSet(test_ramp=[{'pos': 0.0, 'value': 'f', 'interp': rampBasis.Linear}, {'pos': 1.0, 'value': 'bad', 'interp': rampBasis.Linear}])
+    set_bad_interp = ParameterSet(test_ramp=[{'pos': 0.0, 'value': 0.0, 'interp': 'foo'}, {'pos': 1.0, 'value': 0.0, 'interp': 'foo'}])
+    validate_params(spec, set_good)
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_pos)
+    assert_validation(exc_info.value, "ramp point 'pos' must be of type float")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_value)
+    assert_validation(exc_info.value, "ramp point 'value' must be of type float")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_interp)
+    assert_validation(exc_info.value, "ramp point 'interp' must be a valid value from hou.rampBasis")
+
+def test_param_validation_ramp_color():
+    #Ramp color test
+    spec = ParameterSpec(params={
+        'test_ramp': RampParameterSpec(
+            label='test',
+            ramp_parm_type=rampParmType.Color,
+            default=[{'pos': 0.0, 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}])})
+    set_good = ParameterSet(test_ramp=[{'pos': 0.0, 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}, {'pos': 1.0, 'c': [0.0, 0.0, 0.0], 'interp': rampBasis.Linear}])
+    set_bad_pos = ParameterSet(test_ramp=[{'pos': 'd', 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}, {'pos': 'd', 'c': [1.0, 1.0, 1.0], 'interp': rampBasis.Linear}])
+    set_bad_c_outer = ParameterSet(test_ramp=[{'pos': 0.0, 'c': 'f', 'interp': rampBasis.Linear}, {'pos': 1.0, 'c': 'bad', 'interp': rampBasis.Linear}])
+    set_bad_c_inner_type = ParameterSet(test_ramp=[{'pos': 0.0, 'c': ['d','d','d'], 'interp': rampBasis.Linear}, {'pos': 1.0, 'c': ['d','d','d'], 'interp': rampBasis.Linear}])
+    set_bad_c_inner_count = ParameterSet(test_ramp=[{'pos': 0.0, 'c': [0.0, 0.0], 'interp': rampBasis.Linear}, {'pos': 1.0, 'c': [0.0, 0.0], 'interp': rampBasis.Linear}])    
+    set_bad_interp = ParameterSet(test_ramp=[{'pos': 0.0, 'c': [1.0, 1.0, 1.0], 'interp': 'foo'}, {'pos': 1.0, 'c': [0.0, 0.0, 0.0], 'interp': 'foo'}])
+    validate_params(spec, set_good)
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_pos)
+    assert_validation(exc_info.value, "ramp point 'pos' must be of type float")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_c_outer)
+    assert_validation(exc_info.value, "ramp point color 'c' must be of type list")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_c_inner_type)
+    assert_validation(exc_info.value, "ramp point color 'c' must be of type list of floats")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_c_inner_count)
+    assert_validation(exc_info.value, "ramp point color 'c' must be of length 3")
+    with pytest.raises(ParamError) as exc_info:
+        validate_params(spec, set_bad_interp)
+    assert_validation(exc_info.value, "ramp point 'interp' must be a valid value from hou.rampBasis")
 
 def test_param_validation_booleans():
     # Bool parameter test

--- a/libs/python/ripple/tests/test_params_houdini.py
+++ b/libs/python/ripple/tests/test_params_houdini.py
@@ -549,6 +549,24 @@ def test_folder_set_parm_template_class():
     # The single folder's children are empty by default
     assert param_specs == []
 
+def test_hidden_params():
+    #For each parameter type that generates a ParameterSpec
+    #Test that the is_hidden attribute is respected
+    folder=FolderParmTemplate("folder_test", label="FolderTest", folder_type=folderType.Tabs, is_hidden=True)
+    intTemp=IntParmTemplate("int_test", label="IntTest", default_value=[1], num_components=1, is_hidden=True)
+    floatTemp=FloatParmTemplate("float_test", label="FloatTest", default_value=[1.0], num_components=1, is_hidden=True)
+    stringTemp=StringParmTemplate("string_test", label="StringTest", default_value=["Hello"], num_components=1, is_hidden=True)
+    toggleTemp=ToggleParmTemplate("toggle_test", label="ToggleTest", default_value=True, is_hidden=True)
+    menuTemp=MenuParmTemplate("menu_test", label="MenuTest", default_value=1, menu_items=["itemA", "itemB"], menu_labels=["Item A", "Item B"], is_hidden=True)
+    rampTemp=RampParmTemplate("ramp_test", label="RampTest", ramp_part_type=classRampParmType.Float, default_points=[RampPointSpec(pos=0.0, value=0.2)], is_hidden=True)
+
+    assert folder.getParameterSpec()==None
+    assert intTemp.getParameterSpec()==[]
+    assert floatTemp.getParameterSpec()==[]
+    assert stringTemp.getParameterSpec()==[]
+    assert toggleTemp.getParameterSpec()==[]
+    assert menuTemp.getParameterSpec()==[]
+    assert rampTemp.getParameterSpec()==[]
 
 def test_folder_parm_auto_folderset_insertion():
     """


### PR DESCRIPTION
- ramp parms in generate_mesh accepts [{'pos', 'c|value','interp'}]
- respect is_hidden flag when generating parameterSpecs from houClasses
- add rampParameterSpec validation
- update unit tests.