### PR TITLE
{tidy] windows development helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ via their [command line tools](https://developer.1password.com/docs/cli/get-star
 ## Running
 
 Ensure you have [Python3](https://python.org) installed 
+Install poetry for Python globally:
+`pip install poetry`
 
 Setup python `virtual environment` and `invoke`
 
@@ -22,6 +24,10 @@ NB: `/.env.local` supports setting required `env` vars for the infrastructure th
 
 ```bash
 . ./env.sh
+```
+
+```cmd
+env.bat
 ```
 
 
@@ -59,14 +65,14 @@ docker ps -a
 docker logs <container-id>
 ```
 
-## Setup
+## Setup - Linux and Mac
 
 Canonically, we use `asdf` to manage local tool versions. Observe the
 `.tool-versions` file. It is possible to manage your tool versions, but YMMV.
 
 To install all tools:
 
-- [Install `asdf`](https://asdf-vm.com/guide/getting-started.html)
+- [Install `asdf`](https://asdf-vm.com/guinpde/getting-started.html)
 
 - Install plugins:
 
@@ -85,6 +91,10 @@ To install all tools:
 
 For further setup information for Terraform or k8s check the README
 files in those subfolders.
+
+## Setup - Windows
+
+node.js must be installed manually from https://nodejs.org/en/download
 
 ### Install with poetry
 

--- a/api/nginx/debug-entrypoint.bat
+++ b/api/nginx/debug-entrypoint.bat
@@ -1,0 +1,1 @@
+docker run -it --rm -e CONF_FILE=nginx-debug.conf -p 8080:80 --network storage --add-host host.docker.internal:host-gateway --name nginx mythica-web-front:latest

--- a/env.bat
+++ b/env.bat
@@ -1,0 +1,31 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Check if the .infra directory exists
+if not exist .infra (
+    python -m venv .infra
+)
+
+REM Activate the virtual environment
+call .infra\Scripts\activate.bat
+
+REM Load environment variables from .env.local (ignoring comment lines)
+if exist .env.local (
+    for /f "usebackq tokens=1* delims==" %%A in (`findstr /v "^#" .env.local`) do (
+        set "%%A=%%B"
+    )
+)
+
+REM Install local dependencies
+pip install -r local_requirements.txt
+
+echo .
+echo // .infra virtual env activated and updated, use "deactivate" to exit
+echo // use "invoke <task-name> or inv <task-name>" to get started...
+echo. 
+
+inv -l
+
+echo.
+echo // Setup complete. To activate the environment:
+echo call .infra\Scripts\activate.bat


### PR DESCRIPTION
- env.bat for infra repo initialization (NB bat files do not allow modifications to the calling shell so the virtual env needs to be manually activated after calling)
- api/nginx/debug_entrypoint.bat for proxying local debug versions of api and sites on windows (mythica-web-front docker image must be previously built using `inv docker-build --image=api/nginx`