### PR TITLE
[fix] Remove duplicate packager testing deployment

### DIFF
--- a/testing/automation/docker-compose.yaml
+++ b/testing/automation/docker-compose.yaml
@@ -4,17 +4,6 @@ name: automation
 # This docker compose creates a testing environment for automation tier services. 
 #
 services:
-  packager:
-    container_name: packager
-    image: mythica-packager:latest
-    networks:
-      - web
-      - storage
-    environment:
-      MYTHICA_ENVIRONMENT: debug
-      ENV DISCORD_INFRA_ALERTS_WEBHOOK: localhost
-      MYTHICA_ENDPOINT: http://app:5555
-      MYTHICA_API_KEY: ${MYTHICA_API_KEY}
   houdini-worker:
     container_name: houdini
     image: mythica-auto-houdini:latest


### PR DESCRIPTION
Packager was just added to the web tier by #914. Removing the testing deployment from the automation tier. (Causes error if you try to deploy it twice)

The packager is built by the web tier docker-build command, so makes sense to have the deploy in the web tier too.