### PR TITLE
[jungle] Allow camera to zoom out further

### DIFF
--- a/sites/jungle3/src/components/BabylonViewer/SceneViewer.tsx
+++ b/sites/jungle3/src/components/BabylonViewer/SceneViewer.tsx
@@ -133,9 +133,9 @@ const SceneViewer: React.FC<SceneViewerProps> = ({
     camera.setTarget(new BABYLON.Vector3(0, 0.2, 0));
     camera.attachControl(canvasRef.current, true);
     camera.lowerRadiusLimit = 2;
-    camera.upperRadiusLimit = 20;
+    camera.upperRadiusLimit = 150;
     camera.panningSensibility = 0;
-    camera.wheelPrecision = 15;
+    camera.wheelPrecision = 20;
     camera.lowerBetaLimit = 0.2;
     camera.upperBetaLimit = Math.PI / 2.2;
 


### PR DESCRIPTION
The best solution here is some method of auto-zooming the camera to fit the generated model. However in testing this felt jarring to make the camera changing anytime it generates. 

It will require more testing a tweaking to make an auto-zoom approach feel good. For now going to allow the camera to zoom out further to unblock testing of large models.

My current thinking is to add a free camera control mode along with an "F" hotkey to manually recenter the camera on the object. That would provide full control while still preserving a default locked camera experience that is simple.