### PR TITLE
[tidy] decouple SceneControls from jobDefinitions

### DIFF
--- a/sites/jungle3/src/components/BabylonViewer/GeneratorSelector.tsx
+++ b/sites/jungle3/src/components/BabylonViewer/GeneratorSelector.tsx
@@ -33,6 +33,7 @@ const GeneratorSelector: React.FC<GeneratorSelectorProps> = ({
       <Select
         variant="soft"
         name="generator_select"
+        placeholder="Select Generator"
         size="md"
         sx={{ minWidth: 200 }}
         value={selectedHdaId}

--- a/sites/jungle3/src/components/BabylonViewer/SceneControls.tsx
+++ b/sites/jungle3/src/components/BabylonViewer/SceneControls.tsx
@@ -13,7 +13,7 @@ import { JobDefinition } from "@queries/packages/types";
 
 type Props = {
     width: number;
-    jobDefinitions: JobDefinition[] | undefined;
+    jobDefinition: JobDefinition;
     assetVersion: AssetVersionResponse | null;
 };
 
@@ -24,7 +24,7 @@ const isValidMeshFile = (fileName: string): boolean => {
     return VALID_MESH_EXTENSIONS.some(ext => lowerFileName.endsWith(ext));
 };
 
-const SceneControls: React.FC<Props> = ({ width, jobDefinitions,assetVersion }) => {
+const SceneControls: React.FC<Props> = ({ width, jobDefinition,assetVersion }) => {
     const {
         selectedHdaId,
         setSelectedHdaId,
@@ -35,15 +35,12 @@ const SceneControls: React.FC<Props> = ({ width, jobDefinitions,assetVersion }) 
     } = useSceneStore();        
     const parmTemplateGroup = React.useMemo(
         () => {
-            const jobDef = jobDefinitions?.find(
-                (definition) => definition.source.file_id === selectedHdaId,
-            );
             return new hou.ParmTemplateGroup(
-                jobDef?.params_schema.params_v2 as dictionary[],
+                jobDefinition?.params_schema.params_v2 as dictionary[],
             )
         }
         ,
-        [selectedHdaId, jobDefinitions],
+        [selectedHdaId, jobDefinition],
     );
 
     const inputFileParms = parmTemplateGroup.parm_templates.filter(
@@ -105,7 +102,7 @@ const SceneControls: React.FC<Props> = ({ width, jobDefinitions,assetVersion }) 
         }
     }, [hdaFiles]);
 
-    if (!assetVersion || !jobDefinitions )
+    if (!assetVersion )
         return <CircularProgress />;
     
     return (

--- a/sites/jungle3/src/pages/PackageScene.tsx
+++ b/sites/jungle3/src/pages/PackageScene.tsx
@@ -24,6 +24,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useGetAssetByVersion, useGetJobDefinition } from "@queries/packages";
 import { LucideChevronLeft, LucideChevronRight } from "lucide-react";
 import { StatusBar } from "@components/StatusBar";
+import { JobDefinition } from "@queries/packages/types";
 
 export const PackageScene: React.FC = () => {
   const { asset_id, version_id } = useParams();
@@ -210,6 +211,16 @@ export const PackageScene: React.FC = () => {
     }
   }, [fileUpload]);
 
+  const [jobDef, setJobDef] = useState<JobDefinition | null>(null);
+
+  useEffect(() => {
+    setJobDef(
+      jobDefinitions?.find(
+        (definition) => definition.source.file_id === selectedHdaId,
+      ) || null,
+    );
+  }, [selectedHdaId, jobDefinitions]);
+
   // Set loading to false after initial setup
   useEffect(() => {
     setIsLoading(false);
@@ -322,10 +333,18 @@ export const PackageScene: React.FC = () => {
                 flexDirection: "column",
               }}
             >
-              <SceneControls 
-                width={390} 
-                assetVersion={assetVersion}
-                jobDefinitions={jobDefinitions}/>
+              {jobDef ?
+                <SceneControls 
+                  width={390} 
+                  assetVersion={assetVersion}
+                  jobDefinition={jobDef} />
+              : 
+                <Box sx={{ width: 390,padding: "20px" }}>
+                  <Typography level="h4" fontSize="medium">
+                    Select a Generator to continue
+                  </Typography>
+                </Box>
+              } 
             </Box>
           </>
         ) : (
@@ -348,11 +367,18 @@ export const PackageScene: React.FC = () => {
               <ModalClose />
               <DialogTitle>Controls</DialogTitle>
               <DialogContent>
-                <SceneControls
+              {jobDef ?
+                <SceneControls 
                   width={currentWidth - 40}
                   assetVersion={assetVersion}
-                  jobDefinitions={jobDefinitions}
-                />
+                  jobDefinition={jobDef} />
+              : 
+                <Box sx={{ width: currentWidth - 40,padding: "20px" }}> 
+                  <Typography level="h4" fontSize="medium">
+                    Select a Generator to continue
+                  </Typography>
+                </Box>
+              } 
               </DialogContent>
             </ModalDialog>
           </Modal>


### PR DESCRIPTION
Pass in the specified jobDef to scenecontrols rather than make it search for it.