### PR TITLE
[jungle] Fix leaking websocket connections

### DIFF
--- a/sites/libs/scenetalk/src/sceneTalkConnection.ts
+++ b/sites/libs/scenetalk/src/sceneTalkConnection.ts
@@ -15,6 +15,7 @@ export class SceneTalkConnection {
   private maxReconnectAttempts = 5;
   private reconnectTimeout: NodeJS.Timeout | null = null;
   private isReconnecting = false;
+  private shouldAutoReconnect = true;
   private pingInterval: NodeJS.Timeout | null = null;
   private lastPingLatency: number = 0;
   private handlers: {
@@ -46,6 +47,7 @@ export class SceneTalkConnection {
     }
 
     this.ws = new WebSocket(this.wsUrl);
+    this.shouldAutoReconnect = true;
 
     this.ws.onopen = () => {
       console.log("Connected to WebSocket server");
@@ -124,7 +126,7 @@ export class SceneTalkConnection {
 
   // Attempt to reconnect with exponential backoff
   private attemptReconnect() {
-    if (this.isReconnecting || this.reconnectAttempts >= this.maxReconnectAttempts) {
+    if (this.isReconnecting || this.reconnectAttempts >= this.maxReconnectAttempts || !this.shouldAutoReconnect) {
       return;
     }
 
@@ -160,6 +162,7 @@ export class SceneTalkConnection {
 
   // Disconnect from the WebSocket server
   disconnect() {
+    this.shouldAutoReconnect = false;
     this.resetReconnect();
     this.stopPingInterval();
     if (this.ws) {


### PR DESCRIPTION
Bug:
1. Navigate to a PackageScene page with the babylon view.
2. Click the "Back to Package View" button.
3. Wait a few seconds
-> A new websocket connection will be create with the server and be leaked
-> The connection won't be cleaned up until the page is refreshed.

The PackageScene page calls "disconnect" on the sceneTalkConnection object when the page tears down. However this causes the auto-reconnection logic to trigger and cause it to create a new connection. The original page has been torn down and is no longer managing the sceneTalkConnection object so it leaks. This causes the leaked sceneTalkConnection to stick around causing pings to keep hitting the server.

I am unsure why garbage collection is not cleaning up the released sceneTalkConnection object. Fixing the issue by making the released sceneTalkConnection object at least not try to reconnect to the server.