### PR TITLE
[jungle] Fix latency display often showing 0ms

### DIFF
--- a/sites/libs/scenetalk/src/sceneStore.ts
+++ b/sites/libs/scenetalk/src/sceneStore.ts
@@ -170,8 +170,7 @@ export const useSceneStore = create<SceneState>((set) => ({
       statusLog: [],
       exportFormat: null,
       requestInFlight: false,
-      pendingRequest: false,
-      latency: 0,
+      pendingRequest: false
     });
   },
 }));


### PR DESCRIPTION
It would get cleared anytime you changed your selected tool. Also if the initial ping returned quickly, it may cause it to also get cleared due to the components refreshing during initialization.