### PR TITLE
[jungle] Update scenetalk viewer for new geometry format

### DIFF
--- a/sites/awful-ui/src/components/nodes/viewers/ScenetalkViewer.tsx
+++ b/sites/awful-ui/src/components/nodes/viewers/ScenetalkViewer.tsx
@@ -223,14 +223,20 @@ const ScenetalkViewer: React.FC<ScenetalkViewerProps> = (node) => {
             },
 
             onGeometryData: (data) => {
-                if (data.points && data.indices) {
-                    setMeshData({
-                        points: data.points,
-                        indices: data.indices,
-                        normals: data.normals,
-                        uvs: data.uvs,
-                        colors: data.colors,
-                    });
+                const meshes = Object.entries(data);
+                if (meshes.length == 0) {
+                  return;
+                }
+        
+                const mesh = meshes[0][1] as any;
+                if (mesh.points && mesh.indices) {
+                  setMeshData({
+                    points: mesh.points,
+                    indices: mesh.indices,
+                    normals: mesh.normals,
+                    uvs: mesh.uvs,
+                    colors: mesh.colors,
+                  });
                 }
             },
             onFileDownload: (fileName, base64Content) => {

--- a/sites/libs/scenetalk/src/sceneTalkConnector.tsx
+++ b/sites/libs/scenetalk/src/sceneTalkConnector.tsx
@@ -61,13 +61,19 @@ export const SceneTalkConnector: React.FC<SceneTalkConnectorProps> = () => {
         addStatusLog(level, log);
       },
       onGeometryData: (data) => {
-        if (data.points && data.indices) {
+        const meshes = Object.entries(data);
+        if (meshes.length == 0) {
+          return;
+        }
+
+        const mesh = meshes[0][1] as any;
+        if (mesh.points && mesh.indices) {
           setMeshData({
-            points: data.points,
-            indices: data.indices,
-            normals: data.normals,
-            uvs: data.uvs,
-            colors: data.colors,
+            points: mesh.points,
+            indices: mesh.indices,
+            normals: mesh.normals,
+            uvs: mesh.uvs,
+            colors: mesh.colors,
           });
         }
       },


### PR DESCRIPTION
The Geometry payload now contains a dictionary of named sub-meshes: https://github.com/MythicaAI/scenetalk/pull/93

This will allow the client to better display meshes with multiple packed LODs. For now I am making it display only the highest LOD. (First entry in the dict)