### PR TITLE
[jungle] Display cook error in status bar

### DIFF
--- a/sites/libs/scenetalk/src/sceneTalkConnector.tsx
+++ b/sites/libs/scenetalk/src/sceneTalkConnector.tsx
@@ -89,12 +89,12 @@ export const SceneTalkConnector: React.FC<SceneTalkConnectorProps> = () => {
 
         flushStatusLog();
         const currentStatusLog = useSceneStore.getState().statusLog;
-        const errorCount = currentStatusLog.filter(e => e.level === "error").length;
-        const hasErrors = errorCount > 0;
-
-        if (hasErrors) {
-            addStatusLog("error",
-                `Generation completed in ${elapsedTimeInSeconds} ms with errors`);
+        const errors = currentStatusLog.filter(e => e.level === "error");
+        
+        if (errors.length > 0) {
+            const errorMessage = errors[0].log || "Unknown error";
+            addStatusLog("error", 
+                `Failed with error: "${errorMessage}"`);
         } else {
             addStatusLog("info",
                 `Generation completed in ${elapsedTimeInSeconds} ms`);


### PR DESCRIPTION
For tools that require input geometry, the page is unclear as it shows an error when you first load it up. Trying to make that a bit more clear for now by displaying the first error message in the status bar. 

That way you can see "Error: Not enough sources specified." directly on the screen without having to know you need to expand the log pop-up.