### PR TITLE
[gha] push-images add insecure registry config

### DIFF
--- a/.github/workflows/push-tagged-images.yaml
+++ b/.github/workflows/push-tagged-images.yaml
@@ -173,6 +173,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker
+          config-inline: |
+            [registry."mythica-a"]
+              http = true
+              insecure = true
+            [registry."mythica-b"]
+              http = true
+              insecure = true
 
       - name: Google Auth
         id: auth


### PR DESCRIPTION
configure the builder with insecure registries (they are run over tailscale)